### PR TITLE
sync: dont force show "full library sync finished"

### DIFF
--- a/resources/lib/librarysync.py
+++ b/resources/lib/librarysync.py
@@ -1689,7 +1689,7 @@ class LibrarySync(Thread):
                     window('plex_runLibScan', clear=True)
                     window('plex_dbScan', clear=True)
                     # Full library sync finished
-                    self.showKodiNote(string(39407), forced=True)
+                    self.showKodiNote(string(39407), forced=False)
                 # Reset views was requested from somewhere else
                 elif window('plex_runLibScan') == "views":
                     log('Refresh playlist and nodes requested, starting', 0)


### PR DESCRIPTION
if the user deselects "show library sync progress" positive sync messages shouldnt be shown at all.

when the PlexKodiConnect client resumes from s3 sleep this message was shown every time the client was put to sleep before a server induced (even partial) library update which happens at least once a day.
due to the message is force shown it can get quite annoying as the user has no option to silence the message.
this attaches the message to the user configurable option "show library sync progress".