### PR TITLE
fix 'raspberry pi' spelling and capitalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ I'm not in any way affiliated with Plex. Thank you very much for a small donatio
 
 ### IMPORTANT NOTES
 
-1. If your are using a **low CPU device like a raspberry pi or a CuBox**, PKC might be instable or crash during initial sync. Lower the number of threads in the [PKC settings under Sync Options](https://github.com/croneter/PlexKodiConnect/wiki/PKC-settings#sync-options): `Limit artwork cache threads: 5`
+1. If your are using a **low CPU device like a Raspberry Pi or a CuBox**, PKC might be instable or crash during initial sync. Lower the number of threads in the [PKC settings under Sync Options](https://github.com/croneter/PlexKodiConnect/wiki/PKC-settings#sync-options): `Limit artwork cache threads: 5`
 Don't forget to reboot Kodi after that.
 2. If you post logs, your **Plex tokens** might be included. Be sure to double and tripple check for tokens before posting any logs anywhere by searching for `token`
 3. **Compatibility**: PKC is currently not compatible with Kodi's Video Extras plugin. **Deactivate Video Extras** if trailers/movies start randomly playing. 

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -419,7 +419,7 @@
     <string id="39069">Current address:</string>
     <string id="39070">Current port:</string>
     <string id="39071">Current plex.tv status:</string>
-    <string id="39072">Is your Kodi installed on a low-powered device like a raspberry pie? If yes, then we will reduce the strain on Kodi to prevent it from crashing.</string>
+    <string id="39072">Is your Kodi installed on a low-powered device like a Raspberry Pi? If yes, then we will reduce the strain on Kodi to prevent it from crashing.</string>
     <string id="39073">Appearance Tweaks</string>
     <string id="39074">TV Shows</string>
 

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -357,7 +357,7 @@
     <string id="39069">Aktuelle Adresse:</string>
     <string id="39070">Aktueller Port:</string>
     <string id="39071">Aktueller plex.tv Status:</string>
-    <string id="39072">Läuft Kodi auf einem Raspberry Pie oder ähnlichem Computer mit äusserst wenig Rechenleistung? Falls ja, wird die Rechenlast reduziert, damit Kodi nicht abstürzt.</string>
+    <string id="39072">Läuft Kodi auf einem Raspberry Pi oder ähnlichem Gerät mit äusserst wenig Rechenleistung? Falls ja, wird die Rechenlast reduziert, damit Kodi nicht abstürzt.</string>
     <string id="39073">Tweaks Aussehen</string>
     <string id="39074">TV Serien</string>
 

--- a/resources/lib/initialsetup.py
+++ b/resources/lib/initialsetup.py
@@ -474,7 +474,7 @@ class InitialSetup():
             self.logMsg("User opted to use FanArtTV", 1)
             utils.settings('FanartTV', value="true")
 
-        # Is your Kodi installed on a low-powered device like a raspberry pie?
+        # Is your Kodi installed on a low-powered device like a Raspberry Pi?
         # If yes, then we will reduce the strain on Kodi to prevent it from
         # crashing.
         if dialog.yesno(heading=self.addonName,


### PR DESCRIPTION
Raspberry Pi is a proper name thus should be capitalised.

also use "device" instead of "computer" in german translation to bring it in line with the english phrasing.
as kodi can also be deployed on devices which are not necessarily categorized as "computers" in the proper sense (e.g. mobile devices), "device" should fit better here and is correctly utilized in the english translation.