### PR TITLE
MusicLibrary Support

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -8,6 +8,7 @@
     <import addon="script.module.requests" version="2.3.0" />
     <import addon="plugin.video.plexkodiconnect.movies" version="0.01" />
     <import addon="plugin.video.plexkodiconnect.tvshows" version="0.01" />
+    <import addon="plugin.video.plexkodiconnect.music" version="0.01" />
   </requires>
   <extension    point="xbmc.python.pluginsource"
                 library="default.py">

--- a/resources/lib/PlexAPI.py
+++ b/resources/lib/PlexAPI.py
@@ -1206,8 +1206,12 @@ class API():
     def getType(self):
         """
         Returns the type of media, e.g. 'movie' or 'clip' for trailers
+        in case of music, returns the type of the child.
         """
-        return self.item.attrib.get('type')
+        if self.item.attrib.get('type') is not None:
+            return self.item.attrib.get('type')
+        else:
+            return self.item[0].attrib.get('type')
 
     def getChecksum(self):
         """

--- a/resources/lib/itemtypes.py
+++ b/resources/lib/itemtypes.py
@@ -1617,7 +1617,7 @@ class Music(Items):
             if not os.path.exists(xbmc.translatePath(songStrmFileDir)):
                 os.makedirs(xbmc.translatePath(songStrmFileDirTuple))
             #music and movie plugins are thesame anyway, just select one.
-            audioplugin = 'plugin://plugin.video.plexkodiconnect.music/' if os.path.exists(xbmc.translatePath(os.path.join('special://','addons','plugin.video.plexkodiconnect.music'))) else 'plugin://plugin.video.plexkodiconnect.movies/'
+            audioplugin = 'plugin://plugin.video.plexkodiconnect.music/' if os.path.isdir(xbmc.translatePath("/".join(('special:/', 'home', 'addons','plugin.video.plexkodiconnect.music','')))) else 'plugin://plugin.video.plexkodiconnect.movies/'
             with open(xbmc.translatePath("/".join((songStrmFileDir, songStrmFileName))), 'w') as songStrmFile:
                 songStrmFile.write(audioplugin + '?dbid=' + str(songid) + '&mode=play' + '&id=' + str(itemid))
             #Avoid telling kodi in which folder the music files are, so the scraper can't find them (and delete them).

--- a/resources/lib/itemtypes.py
+++ b/resources/lib/itemtypes.py
@@ -3,11 +3,13 @@
 ###############################################################################
 
 import logging
+import os
 from urllib import urlencode
 from ntpath import dirname
 from datetime import datetime
 
 import xbmcgui
+import xbmc
 
 import artwork
 from utils import tryEncode, tryDecode, settings, window, kodiSQL, \
@@ -1605,9 +1607,22 @@ class Music(Items):
         if doIndirect:
             # Plex works a bit differently
             path = "%s%s" % (self.server, item[0][0].attrib.get('key'))
-            path = API.addPlexCredentialsToUrl(path)
-            filename = path.rsplit('/', 1)[1]
-            path = path.replace(filename, '')
+            ## The old way of doing stuff
+            #path = API.addPlexCredentialsToUrl(path)
+            #filename = path.rsplit('/', 1)[1]
+            #path = path.replace(filename, '')
+            ## now using .strm files instead to circumvent the inability to launch plugins directly from the library for music files
+            songStrmFileDir = "/".join(('special:/', 'userdata', 'addon_data', 'plugin.video.plexkodiconnect', 'musicstreamfiles', ''))
+            songStrmFileName = str(songid) + '.strm'
+            if not os.path.exists(xbmc.translatePath(songStrmFileDir)):
+                os.makedirs(xbmc.translatePath(songStrmFileDirTuple))
+            #music and movie plugins are thesame anyway, just select one.
+            audioplugin = 'plugin://plugin.video.plexkodiconnect.music/' if os.path.exists(xbmc.translatePath(os.path.join('special://','addons','plugin.video.plexkodiconnect.music'))) else 'plugin://plugin.video.plexkodiconnect.movies/'
+            with open(xbmc.translatePath("/".join((songStrmFileDir, songStrmFileName))), 'w') as songStrmFile:
+                songStrmFile.write(audioplugin + '?dbid=' + str(songid) + '&mode=play' + '&id=' + str(itemid))
+            #Avoid telling kodi in which folder the music files are, so the scraper can't find them (and delete them).
+            path = ''
+            filename = "/".join((songStrmFileDir, songStrmFileName))
 
         # UPDATE THE SONG #####
         if update_item:

--- a/resources/lib/playbackutils.py
+++ b/resources/lib/playbackutils.py
@@ -9,6 +9,7 @@ from urllib import urlencode
 import xbmc
 import xbmcgui
 import xbmcplugin
+import os
 
 import playutils as putils
 import playlist
@@ -132,7 +133,8 @@ class PlaybackUtils():
                     dbid,
                     PF.KODITYPE_FROM_PLEXTYPE[API.getType()])
                 if kodiPl[self.currentPosition+1].getfilename().endswith(".strm"):
-                    kodiPl[self.currentPosition+1].setPath(playurl)
+                    audioplugin = 'plugin://plugin.video.plexkodiconnect.music/' if os.path.isdir(xbmc.translatePath("/".join(('special:/', 'home', 'addons','plugin.video.plexkodiconnect.music','')))) else 'plugin://plugin.video.plexkodiconnect.movies/'
+                    kodiPl[self.currentPosition+1].setPath(audioplugin + "?dbid=" + str(dbid) + "&mode=play&id=" + str(itemid))
                 self.currentPosition += 1
 
             ############### -- CHECK FOR INTROS ################
@@ -177,7 +179,8 @@ class PlaybackUtils():
                         dbid,
                         PF.KODITYPE_FROM_PLEXTYPE[API.getType()])
                     if kodiPl[self.currentPosition+1].getfilename().endswith(".strm"):
-                        kodiPl[self.currentPosition+1].setPath(playurl)
+                        audioplugin = 'plugin://plugin.video.plexkodiconnect.music/' if os.path.isdir(xbmc.translatePath("/".join(('special:/', 'home', 'addons','plugin.video.plexkodiconnect.music','')))) else 'plugin://plugin.video.plexkodiconnect.movies/'
+                        kodiPl[self.currentPosition+1].setPath(audioplugin + "?dbid=" + str(dbid) + "&mode=play&id=" + str(itemid))
                 self.currentPosition += 1
                 if seektime:
                     window('plex_customplaylist.seektime', value=str(seektime))

--- a/resources/lib/playbackutils.py
+++ b/resources/lib/playbackutils.py
@@ -131,6 +131,8 @@ class PlaybackUtils():
                     self.currentPosition+1,
                     dbid,
                     PF.KODITYPE_FROM_PLEXTYPE[API.getType()])
+                if kodiPl[self.currentPosition+1].getfilename().endswith(".strm"):
+                    kodiPl[self.currentPosition+1].setPath(playurl)
                 self.currentPosition += 1
 
             ############### -- CHECK FOR INTROS ################
@@ -174,6 +176,8 @@ class PlaybackUtils():
                         self.currentPosition+1,
                         dbid,
                         PF.KODITYPE_FROM_PLEXTYPE[API.getType()])
+                    if kodiPl[self.currentPosition+1].getfilename().endswith(".strm"):
+                        kodiPl[self.currentPosition+1].setPath(playurl)
                 self.currentPosition += 1
                 if seektime:
                     window('plex_customplaylist.seektime', value=str(seektime))

--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -159,6 +159,9 @@ class PlayUtils():
                 (excepting trailers etc.)
         if the corresponding file settings are set to 'true'
         """
+        if self.API.getType() == 'track':
+            #We are dealing with a music file here, returning False to asume Kodi can play all audio files 
+            return False
         videoCodec = self.API.getVideoCodec()
         log.info("videoCodec: %s" % videoCodec)
         if (settings('transcodeHi10P') == 'true' and

--- a/resources/lib/websocket_client.py
+++ b/resources/lib/websocket_client.py
@@ -44,6 +44,8 @@ class WebSocket(threading.Thread):
 
         # Triage
         typus = message.get('type')
+        if 'NotificationContainer' in message:
+            typus = message['NotificationContainer'].get('type')
         if typus is None:
             log.error('No message type, dropping message: %s' % message)
             return False


### PR DESCRIPTION
Musiclibrary has been requested by several people and listed bugs (https://github.com/croneter/PlexKodiConnect/issues/14 and https://github.com/croneter/PlexKodiConnect/issues/21) that it kind of breaks kodi now. I had a try at implementing this feature.

When the same method is used as for movies; that is, directing the library path to the corresponding plugin. This doesn't work for the music library as it doesn't allow launching a plugin from the library.
This can be circumvented by using .strm files, these are picked up and can be used to redirect the music entry to the pkc plugin.

The current method is to generate .strm files in addon_data/pkc/musicstreamfiles/*dbid*.strm with the pkc entry (e.g. plugin://plugin.video.plexkodiconnect.music/?dbid=1&mode=play&id=20182) and start these instead. Some optimizations had to be added to the script to take music files into account.

key features:
- generate *.strm file with plugin, dbid and itemid
- using plugin.video.plexkodiconnect.music or plugin.video.plexkodiconnect.movies (they are both thesame and automatically chosen, but the former preferred)
- *.strm files added to library
- complete metadata support

- the music scraper still doesn't like this approach, and deletes the entries from the library. A solution was found by introducing the directory as blank and the filenames used to directly access the files. It does show the following in the log: "MUSIC_INFO::CMusicInfoScanner::Process directory '' does not exist - skipping scan." but this is harmless. 

For now tested on Windows, Kodi 16.1 using NAS PMS (synology 1.3.2.3112) or Windows PMS (1.3.2.3112).