### PR TITLE
Plex RAW photos/picture support

### DIFF
--- a/resources/lib/PlexAPI.py
+++ b/resources/lib/PlexAPI.py
@@ -2360,7 +2360,14 @@ class API():
         listItem.setProperty('IsPlayable', 'true')
         if settings('useDirectPaths') == '0':
             # Addon paths
-            path = self.addPlexCredentialsToUrl(
+            if not self.item[0][0].attrib['key'][self.item[0][0].attrib['key'].rfind('.'):].lower() in ('.bmp', '.jpg', '.jpeg', '.gif', '.png', '.tiff', '.mng', '.ico', '.pcx', '.tga'):
+                # Check if Kodi supports the file, if not transcode it by Plex
+                # extensions from: http://kodi.wiki/view/Features_and_supported_codecs#Format_support (RAW image formats, BMP, JPEG, GIF, PNG, TIFF, MNG, ICO, PCX and Targa/TGA)
+                path = str(self.server) + str(PlexAPI().getTranscodeImagePath(self.item[0][0].attrib.get('key'), window('pms_token'), "%s%s" % (self.server, self.item[0][0].attrib.get('key')), 1920, 1080))
+                # max width/height supported by plex image transcoder is 1920x1080
+            else:
+                # Just give the path of the file to Kodi
+                path = self.addPlexCredentialsToUrl(
                 '%s%s' % (window('pms_server'),
                           self.item[0][0].attrib['key']))
         else:


### PR DESCRIPTION
This feature was requested in issue https://github.com/croneter/PlexKodiConnect/issues/164. 

 ## Approach
It is quite simple to implement by passing the path of the RAW image file, through the
getTranscodeImagePath function in the PlexAPI class. The path is then exchanged for `https://<plexip>:32400/photo/:/transcode/1920x1080/<path>?url=http://127.0.0.1:32400/<key>&width=1920&height=1080&Plex-Token=<token>`. This requests Plex
to transcode the file before sending it to Kodi. The 127.0.0.1 address directs plex to itself instead and is basically the same as using the server url.

 ## Disadvantages
- This is always active for all RAW files, there is support for RAW files in Kodi but with issues (e.g. http://forum.kodi.tv/showthread.php?tid=167127, but my own .ARW files did not work either in Kodi). It might be better to either make a menu item to disable RAW photo transcoding or keep track of the files that have to be transcoded. Though, to my knowledge there is no feedback on the playability by Kodi.
- A small disadvantage of this approach is the maximum resolution of 1920x1080, but I doubt that will impact many people.