### PR TITLE
apply limit to OnDeck if OnDeckTVextended not set

### DIFF
--- a/resources/lib/entrypoint.py
+++ b/resources/lib/entrypoint.py
@@ -754,6 +754,7 @@ def getOnDeck(viewid, mediatype, tagname, limit):
         if xml in (None, 401):
             log.error('Could not download PMS xml for view %s' % viewid)
             return xbmcplugin.endOfDirectory(HANDLE)
+        limitcounter = 0
         for item in xml:
             api = API(item)
             listitem = api.CreateListItemFromPlexItem(
@@ -775,6 +776,9 @@ def getOnDeck(viewid, mediatype, tagname, limit):
                 handle=HANDLE,
                 url=url,
                 listitem=listitem)
+            limitcounter += 1
+            if limitcounter == limit:
+                break
         return xbmcplugin.endOfDirectory(
             handle=HANDLE,
             cacheToDisc=settings('enableTextureCache') == 'true')


### PR DESCRIPTION
This covers part 2 of issue #190.
I plan on doing a separate PR for part 1, as that one is more complex and should allow you to decide independently if you want to merge the changes.
Should you prefer to receive proposals differently, feel free to let me know. 
At this point I would also like to mention that I think the second part of getOnDeck should be removed in my opinion as it does not really mimic Plex and the result would look different from PMS itself. Besides, if someone wanted to see the next Episode of all shows, there would already be the method 'nextUpEpisodes', which could be added as a separate video node. 
If you were to agree with this, please note that the Appearance Tweak settings 'Extend OnDeck to all Shows' would become obsolete as a pure "OnDeck" does not allow that.
Happy to discuss as usual - this PR only fixes the Limit application though.
