### PR TITLE
fix small bug to get nextup woking

### DIFF
--- a/default.py
+++ b/default.py
@@ -133,7 +133,7 @@ class Main():
 
             elif mode in ("nextup", "inprogressepisodes"):
                 limit = int(params['limit'])
-                modes[mode](itemid, limit)
+                modes[mode](params['tagname'], limit)
             
             elif mode in ("channels","getsubfolders"):
                 modes[mode](itemid)


### PR DESCRIPTION
The `entrypoint.py` subs `getNextUpEpisodes` and `getInProgressEpisodes` are expecting 'tagname' as first argument, not 'itemid'. With this fix the query works, e.g. with a manually generated video-node.
It does seem to have a logical issue though as it always filters for "inprogress" TV Shows, regardless of the PKC Parameter "Extend Plex TV Series 'On Deck' view to all shows". You may argue that this setting was meant for OnDeck only, but the second part of `getOnDeck` also contains that filter (line 794).

I will probably try to get a "Next Up Episodes" video-node to the PKC generated TV Show folder, but if I get to it I'll produce a separate PR for that.
Thanks again for your great on this awesome tool.