### PR TITLE
add setting to chose season rather than show poster for PMS widget items

### DIFF
--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -444,6 +444,7 @@
     <string id="39077">Počet položek pro zobrazení ve widgetech (např. "Aktuální")</string>
     <string id="39078">Port aktualizace Plex Companion (změňte pouze pokud je nutné)</string>
     <string id="39079">Plex Companion nemůže otevřít GDM port. Prosím změňte ho v nastavení PKC.</string>
+    <string id="39080">Use season (instead show) posters for PMS items</string>
 
     <!-- Plex Entrypoint.py -->
     <string id="39200">Odhlásit uživatele Plex Home </string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -444,6 +444,7 @@
     <string id="39077">Number of PMS items to show in widgets (e.g. "On Deck")</string>
     <string id="39078">Plex Companion Update Port (change only if needed)</string>
     <string id="39079">Plex Companion could not open the GDM port. Please change it in the PKC settings.</string>
+    <string id="39080">Use season (instead show) posters for PMS items</string>
 
     <!-- Plex Entrypoint.py -->
     <string id="39200">Log-out Plex Home User </string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -444,6 +444,7 @@
     <string id="39077">Anzahl anzuzeigender PMS Einträge in Widgets (z.B. "Aktuell")</string>
     <string id="39078">Plex Companion Update Port (nur bei Bedarf ändern)</string>
     <string id="39079">Plex Companion konnte den Update Port nicht öffnen. Bitte den Port in den PKC Einstellungen ändern.</string>
+    <string id="39080">Benütze Staffel (statt Serien) Poster für PMS Einträge</string>
 
     <!-- Plex Entrypoint.py -->
     <string id="39200">Plex Home Benutzer abmelden: </string>

--- a/resources/language/Spanish/strings.xml
+++ b/resources/language/Spanish/strings.xml
@@ -444,6 +444,7 @@
     <string id="39077">Número de elementos del PMS a mostrar en widgets (por ejemplo "On Deck")</string>
     <string id="39078">Puerto de Actualización de Plex Companion (solo cambie si es necesario)</string>
     <string id="39079">Plex Companion no pudo abrir el puerto GDM. Por favor cámbielo en los ajustes de PKC.</string>
+    <string id="39080">Use season (instead show) posters for PMS items</string>
 
     <!-- Plex Entrypoint.py -->
     <string id="39200">Terminar sesión del usuario de Plex Home </string>

--- a/resources/lib/PlexAPI.py
+++ b/resources/lib/PlexAPI.py
@@ -1820,7 +1820,10 @@ class API():
         # Banner (usually only on tv series level)
         allartworks['Banner'] = self.__getOneArtwork('banner')
         # For e.g. TV shows, get series thumb
-        allartworks['Thumb'] = self.__getOneArtwork('grandparentThumb')
+        if settings('useSeasonPosterRatherThanShowPoster') == 'true':
+            allartworks['Thumb'] = self.__getOneArtwork('parentThumb')
+        else:
+            allartworks['Thumb'] = self.__getOneArtwork('grandparentThumb')
 
         # Process parent items if the main item is missing artwork
         if parentInfo:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -134,6 +134,7 @@
 	<category label="39073"><!-- Appearance Tweaks -->
 		<setting id="fetch_pms_item_number" label="39077" type="number" default="25" option="int" />
 		<setting type="lsep" label="39074" /><!-- TV Shows -->
+        <setting id="useSeasonPosterRatherThanShowPoster" type="bool" label="39080" default="true" /><!-- Use season (instead show) posters for PMS items -->
 		<setting id="OnDeckTVextended" type="bool" label="39058" default="true" /><!-- Extend Plex TV Series "On Deck" view to all shows -->
 		<setting id="OnDeckTvAppendShow" type="bool" label="39047" default="false" /><!--On Deck view: Append show title to episode-->
 		<setting id="OnDeckTvAppendSeason" type="bool" label="39048" default="false" /><!--On Deck view: Append season number to episode-->


### PR DESCRIPTION
As already mentioned in my other PR, this introduces a new setting (under appearance tweaks) that allows the user to specify if he would rather see show level posters in widgets like 'On Deck' or 'Recently Added Episodes' or if he prefers season level posters.
The concept of reading settings directly in plexAPI.py may not be very neat, but it works fine. A change of that setting seems to require a restart of Kodi though. If you would rather do this differently, I am open to suggestions.
As I don't know Czeck or Spanish, I temporarily added the English string to the respective files (separate commit on purpose) as I figured it would be better to have something of a foreign language than nothing at all. If you have a better way to handle this, feel free again to share.