### PR TITLE
Fix Plex Web Issue

### DIFF
--- a/resources/lib/plexbmchelper/listener.py
+++ b/resources/lib/plexbmchelper/listener.py
@@ -58,7 +58,7 @@ class MyHandler(BaseHTTPRequestHandler):
             'x-plex-version, x-plex-platform-version, x-plex-username, '
             'x-plex-client-identifier, x-plex-target-client-identifier, '
             'x-plex-device-name, x-plex-platform, x-plex-product, accept, '
-            'x-plex-device')
+            'x-plex-device, x-plex-device-screen-resolution')
         self.end_headers()
         self.wfile.close()
 


### PR DESCRIPTION
Causes issues with Plex web due to Access-Control-Allow-Headers missing header.

I was getting the following browser error:
XMLHttpRequest cannot load http://***:3005/player/timeline/poll?wait=0&commandID=0. Request header field X-Plex-Device-Screen-Resolution is not allowed by Access-Control-Allow-Headers in preflight response.