### PR TITLE
Play state improvements

### DIFF
--- a/resources/lib/itemtypes.py
+++ b/resources/lib/itemtypes.py
@@ -158,6 +158,12 @@ class Items(object):
         # If the playback was stopped, check whether we need to increment the
         # playcount. PMS won't tell us the playcount via websockets
         if item['state'] in ('stopped', 'ended'):
+
+            # If offset exceeds duration skip update
+            if item['viewOffset'] > item['duration']:
+              log.error("Error while updating play state, viewOffset exceeded duration")
+              return
+
             complete = float(item['viewOffset']) / float(item['duration'])
             log.info('Item %s stopped with completion rate %s percent.'
                      'Mark item played at %s percent.'

--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -92,6 +92,7 @@ class KodiMonitor(Monitor):
             # Manually marking as watched/unwatched
             playcount = data.get('playcount')
             item = data.get('item')
+
             try:
                 kodiid = item['id']
                 item_type = item['type']
@@ -114,7 +115,7 @@ class KodiMonitor(Monitor):
                         window('plex_skipWatched%s' % itemid, clear=True)
                     else:
                         # notify the server
-                        if playcount != 0:
+                        if playcount > 0:
                             scrobble(itemid, 'watched')
                         else:
                             scrobble(itemid, 'unwatched')


### PR DESCRIPTION
Improvements to play state monitoring to make sure it doesn't incorrectly set items as watched, relates to issue #279 , 

Another improvement would be in library sync however in the Kodi payload there it's missing some information (duration / playcount / last_played) to make sure it uses latest play state info or duration <-> offset checks for both ends.
So that isn't possible yet but these changes should help prevent any invalid play states if either Kodi or Plex has some invalid offsets.