### PR TITLE
Update Leia DB versions as per https://kodi.wiki/view/Databases

### DIFF
--- a/resources/lib/variables.py
+++ b/resources/lib/variables.py
@@ -84,7 +84,7 @@ _DB_VIDEO_VERSION = {
     15: 93,   # Isengard
     16: 99,   # Jarvis
     17: 107,  # Krypton
-    18: 108   # Leia
+    18: 109   # Leia
 }
 DB_VIDEO_PATH = try_decode(xbmc.translatePath(
     "special://database/MyVideos%s.db" % _DB_VIDEO_VERSION[KODIVERSION]))
@@ -95,7 +95,7 @@ _DB_MUSIC_VERSION = {
     15: 52,   # Isengard
     16: 56,   # Jarvis
     17: 60,   # Krypton
-    18: 62    # Leia
+    18: 70    # Leia
 }
 DB_MUSIC_PATH = try_decode(xbmc.translatePath(
     "special://database/MyMusic%s.db" % _DB_MUSIC_VERSION[KODIVERSION]))


### PR DESCRIPTION
The official kodi database table shows that alpha 1 is currently using video db version 109, and music version 70.  This sets these versions correctly in variables.py, so new versions PKC don't revert to an incorrect db version.  https://kodi.wiki/view/Databases#Database_Versions