### PR TITLE
Fix Kodi profile switch not working correctly and PKC not exiting cleanly

### DIFF
--- a/resources/lib/service_entry.py
+++ b/resources/lib/service_entry.py
@@ -91,10 +91,6 @@ class Service(object):
         for prop in WINDOW_PROPERTIES:
             utils.window(prop, clear=True)
 
-        # To detect Kodi profile switches
-        utils.window('plex_kodiProfile',
-                     value=utils.try_decode(xbmc.translatePath("special://profile")))
-
         # Load/Reset PKC entirely - important for user/Kodi profile switch
         # Clear video nodes properties
         library_sync.VideoNodes().clearProperties()
@@ -423,13 +419,6 @@ class Service(object):
 
         # Main PKC program loop
         while not self.isCanceled():
-            # Check for Kodi profile change
-            if utils.window('plex_kodiProfile') != v.KODI_PROFILE:
-                # Profile change happened, terminate this thread and others
-                LOG.info("Kodi profile was: %s and changed to: %s. "
-                         "Terminating old PlexKodiConnect thread.",
-                         v.KODI_PROFILE, utils.window('plex_kodiProfile'))
-                break
 
             # Check for PKC commands from other Python instances
             plex_command = utils.window('plexkodiconnect.command')

--- a/resources/lib/service_entry.py
+++ b/resources/lib/service_entry.py
@@ -35,7 +35,7 @@ STRINGS = (utils.try_encode(utils.lang(12021)),
            utils.try_encode(utils.lang(12023)))
 
 
-class Service():
+class Service(object):
     ws = None
     sync = None
     plexcompanion = None

--- a/resources/lib/websocket_client.py
+++ b/resources/lib/websocket_client.py
@@ -48,6 +48,16 @@ class WebSocket(backgroundthread.KillableThread):
     def run(self):
         LOG.info("----===## Starting %s ##===----", self.__class__.__name__)
         app.APP.register_thread(self)
+        try:
+            self._run()
+        finally:
+            # Close websocket connection on shutdown
+            if self.ws is not None:
+                self.ws.close()
+            app.APP.deregister_thread(self)
+            LOG.info("##===---- %s Stopped ----===##", self.__class__.__name__)
+
+    def _run(self):
         counter = 0
         while not self.isCanceled():
             # In the event the server goes offline
@@ -133,11 +143,6 @@ class WebSocket(backgroundthread.KillableThread):
                 if self.ws is not None:
                     self.ws.close()
                 self.ws = None
-        # Close websocket connection on shutdown
-        if self.ws is not None:
-            self.ws.close()
-        app.APP.deregister_thread(self)
-        LOG.info("##===---- %s Stopped ----===##", self.__class__.__name__)
 
 
 class PMS_Websocket(WebSocket):


### PR DESCRIPTION
Calls to `xbmc.getCondVisibility` when PKC should exit (`xbmc.abortRequested=True`?) will never return