### PR TITLE
Fix sync not working due to non-ASCII Plex library names

### DIFF
--- a/resources/lib/library_sync/sections.py
+++ b/resources/lib/library_sync/sections.py
@@ -99,7 +99,7 @@ class Section(object):
                 "'section_type': '{self.section_type}', "
                 "'sync_to_kodi': {self.sync_to_kodi}, "
                 "'last_sync': {self.last_sync}"
-                "}}").format(self=self)
+                "}}").format(self=self).encode('utf-8')
     __str__ = __repr__
 
     def __nonzero__(self):


### PR DESCRIPTION
- Fixes #772
