### PR TITLE
Fix rare UnicodeDecodeError on library sync

### DIFF
--- a/resources/lib/plex_api/file.py
+++ b/resources/lib/plex_api/file.py
@@ -138,12 +138,12 @@ class File(object):
                 return
         try:
             if force_first_media is False:
-                ans = cast(str, self.xml[self.mediastream][self.part].attrib['file'])
+                ans = self.xml[self.mediastream][self.part].attrib['file']
             else:
-                ans = cast(str, self.xml[0][self.part].attrib['file'])
+                ans = self.xml[0][self.part].attrib['file']
         except (TypeError, AttributeError, IndexError, KeyError):
             return
-        return utils.unquote(ans)
+        return ans
 
     def get_picture_path(self):
         """


### PR DESCRIPTION
- Fixes #863
- urllib.unquote() is not needed anymore for Plex' `file` attribute
- urllib.unquote() seems to choke on `%` that are not to be unquoted(?)