### PR TITLE
 Fix PKC creating thousands of playlists if a single Kodi playlist wasn't unique

### DIFF
--- a/resources/lib/migration.py
+++ b/resources/lib/migration.py
@@ -42,4 +42,13 @@ def check_migration():
         sections.clear_window_vars()
         sections.delete_videonode_files()
 
+    if not utils.compare_version(last_migration, '2.8.7'):
+        LOG.info('Migrating to version 2.8.6')
+        # Need to delete the UNIQUE index that prevents creating several
+        # playlist entries with the same kodi_hash
+        from .plex_db import PlexDB
+        with PlexDB() as plexdb:
+            plexdb.cursor.execute('DROP INDEX IF EXISTS ix_playlists_3')
+            # Index will be automatically recreated on next PKC startup
+
     utils.settings('last_migrated_PKC_version', value=v.ADDON_VERSION)

--- a/resources/lib/playlists/db.py
+++ b/resources/lib/playlists/db.py
@@ -47,15 +47,13 @@ def update_playlist(playlist, delete=False):
             plexdb.add_playlist(playlist)
 
 
-def get_playlist(path=None, kodi_hash=None, plex_id=None):
+def get_playlist(path=None, plex_id=None):
     """
-    Returns the playlist as a Playlist for either the plex_id, path or
-    kodi_hash. kodi_hash will be more reliable as it includes path and file
-    content.
+    Returns the playlist as a Playlist for either the plex_id or path
     """
     playlist = Playlist()
     with PlexDB() as plexdb:
-        playlist = plexdb.playlist(playlist, plex_id, path, kodi_hash)
+        playlist = plexdb.playlist(playlist, plex_id, path)
     return playlist
 
 

--- a/resources/lib/plex_db/common.py
+++ b/resources/lib/plex_db/common.py
@@ -305,7 +305,7 @@ def initialize():
                 'CREATE INDEX IF NOT EXISTS ix_track_1 ON track (last_sync)',
                 'CREATE UNIQUE INDEX IF NOT EXISTS ix_track_2 ON track (kodi_id)',
                 'CREATE UNIQUE INDEX IF NOT EXISTS ix_playlists_2 ON playlists (kodi_path)',
-                'CREATE UNIQUE INDEX IF NOT EXISTS ix_playlists_3 ON playlists (kodi_hash)',
+                'CREATE INDEX IF NOT EXISTS ix_playlists_3 ON playlists (kodi_hash)',
             )
             for cmd in commands:
                 plexdb.cursor.execute(cmd)

--- a/resources/lib/plex_db/playlists.py
+++ b/resources/lib/plex_db/playlists.py
@@ -57,20 +57,17 @@ class Playlists(object):
              playlist.kodi_type,
              playlist.kodi_hash))
 
-    def playlist(self, playlist, plex_id=None, path=None, kodi_hash=None):
+    def playlist(self, playlist, plex_id=None, path=None):
         """
-        Returns a complete Playlist (empty one passed in via playlist)
-        for the entry with plex_id OR kodi_hash OR kodi_path.
+        Returns a complete Playlist (empty one passed in via playlist) for the
+        entry with plex_id OR kodi_path.
         Returns None if not found
         """
         query = 'SELECT * FROM playlists WHERE %s = ? LIMIT 1'
         if plex_id:
             query = query % 'plex_id'
             var = plex_id
-        elif kodi_hash:
-            query = query % 'kodi_hash'
-            var = kodi_hash
-        else:
+        elif path:
             query = query % 'kodi_path'
             var = path
         self.cursor.execute(query, (var, ))


### PR DESCRIPTION
- Cause: unique index wasn't really unique. Python sqlite failed silently (thanks very much)
- To reproduce the original bug: simply copy-paste an existing playlist file on the Kodi side