### PR TITLE
Fix Play Error in scenarios (older PMS version?) where posting playqueues using an uri `server://` is not possible and `library://` is necessary

### DIFF
--- a/resources/lib/playback.py
+++ b/resources/lib/playback.py
@@ -235,7 +235,10 @@ def _playback_init(plex_id, plex_type, playqueue, pos):
     playqueue.clear()
     if plex_type != v.PLEX_TYPE_CLIP:
         # Post to the PMS to create a playqueue - in any case due to Companion
-        xml = PF.init_plex_playqueue(plex_id, plex_type, trailers=trailers)
+        xml = PF.init_plex_playqueue(plex_id,
+                                     plex_type,
+                                     xml.get('librarySectionUUID'),
+                                     trailers=trailers)
         if xml is None:
             LOG.error('Could not get a playqueue xml for plex id %s', plex_id)
             # "Play error"


### PR DESCRIPTION
- Introduced by 0d7a1b3a9f1828b550d508848c2b3e07801bbcf8
- Fixes #999 
