### PR TITLE
Futurize: render PKC compatible with Python 2 AND 3

### DIFF
--- a/contextmenu.py
+++ b/contextmenu.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 from sys import listitem
-from urllib import urlencode
+from urllib.parse import urlencode
 
 from xbmc import getCondVisibility, sleep
 from xbmcgui import Window

--- a/default.py
+++ b/default.py
@@ -2,9 +2,12 @@
 
 ###############################################################################
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 import logging
 from sys import argv
-from urlparse import parse_qsl
+from urllib.parse import parse_qsl
 
 import xbmc
 import xbmcgui
@@ -23,7 +26,7 @@ LOG = logging.getLogger('PLEX.default')
 HANDLE = int(argv[1])
 
 
-class Main():
+class Main(object):
     # MAIN ENTRY POINT
     # @utils.profiling()
     def __init__(self):
@@ -33,7 +36,7 @@ class Main():
         arguments = unicode_paths.decode(argv[2])
         path = unicode_paths.decode(argv[0])
         # Ensure unicode
-        for key, value in params.iteritems():
+        for key, value in params.items():
             params[key.decode('utf-8')] = params.pop(key)
             params[key] = value.decode('utf-8')
         mode = params.get('mode', '')

--- a/resources/lib/app/account.py
+++ b/resources/lib/app/account.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 
 from .. import utils

--- a/resources/lib/app/application.py
+++ b/resources/lib/app/application.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 from logging import getLogger
-import Queue
+import queue
 from threading import Lock, RLock
 
 import xbmc
@@ -38,9 +41,9 @@ class App(object):
             self.lock_playlists = Lock()
 
             # Plex Companion Queue()
-            self.companion_queue = Queue.Queue(maxsize=100)
+            self.companion_queue = queue.Queue(maxsize=100)
             # Websocket_client queue to communicate with librarysync
-            self.websocket_queue = Queue.Queue()
+            self.websocket_queue = queue.Queue()
             # xbmc.Monitor() instance from kodimonitor.py
             self.monitor = None
             # xbmc.Player() instance

--- a/resources/lib/app/connection.py
+++ b/resources/lib/app/connection.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 
 from .. import utils, json_rpc as js, variables as v

--- a/resources/lib/app/libsync.py
+++ b/resources/lib/app/libsync.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
 
+from builtins import object
 from .. import utils
 
 

--- a/resources/lib/app/playstate.py
+++ b/resources/lib/app/playstate.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 
+from builtins import object
 class PlayState(object):
     # "empty" dict for the PLAYER_STATES above. Use copy.deepcopy to duplicate!
     template = {

--- a/resources/lib/backgroundthread.py
+++ b/resources/lib/backgroundthread.py
@@ -332,6 +332,21 @@ class Task(object):
     def __cmp__(self, other):
         return self.priority - other.priority
 
+    def __eq__(self, other):
+        return self.priority == other.priority
+
+    def __lt__(self, other):
+        return self.priority < other.priority
+
+    def __le__(self, other):
+        return self.priority <= other.priority
+
+    def __gt__(self, other):
+        return self.priority > other.priority
+
+    def __ge__(self, other):
+        return self.priority >= other.priority
+
     def start(self):
         BGThreader.addTask(self)
 

--- a/resources/lib/clientinfo.py
+++ b/resources/lib/clientinfo.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
 from logging import getLogger
 
 import xbmc

--- a/resources/lib/companion.py
+++ b/resources/lib/companion.py
@@ -28,7 +28,7 @@ def skip_to(params):
     LOG.debug('Skipping to playQueueItemID %s, plex_id %s',
               playqueue_item_id, plex_id)
     found = True
-    for player in js.get_players().values():
+    for player in list(js.get_players().values()):
         playqueue = PQ.PLAYQUEUES[player['playerid']]
         for i, item in enumerate(playqueue.items):
             if item.id == playqueue_item_id:

--- a/resources/lib/context_entry.py
+++ b/resources/lib/context_entry.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 import xbmc
 import xbmcgui

--- a/resources/lib/db.py
+++ b/resources/lib/db.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import sqlite3
 from functools import wraps
 

--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 import requests
 import requests.exceptions as exceptions
@@ -18,7 +19,7 @@ LOG = getLogger('PLEX.download')
 ###############################################################################
 
 
-class DownloadUtils():
+class DownloadUtils(object):
     """
     Manages any up/downloads with PKC. Careful to initiate correctly
     Use startSession() to initiate.

--- a/resources/lib/entrypoint.py
+++ b/resources/lib/entrypoint.py
@@ -5,6 +5,7 @@ Loads of different functions called in SEPARATE Python instances through
 e.g. plugin://... calls. Hence be careful to only rely on window variables.
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import range
 from logging import getLogger
 import sys
 

--- a/resources/lib/initialsetup.py
+++ b/resources/lib/initialsetup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
+from builtins import range
+from builtins import object
 from logging import getLogger
 
 from xbmc import executebuiltin

--- a/resources/lib/itemtypes/common.py
+++ b/resources/lib/itemtypes/common.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 from ntpath import dirname
 

--- a/resources/lib/itemtypes/music.py
+++ b/resources/lib/itemtypes/music.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 
 from .common import ItemBase

--- a/resources/lib/itemtypes/tvshows.py
+++ b/resources/lib/itemtypes/tvshows.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 
 from .common import ItemBase, process_path

--- a/resources/lib/json_rpc.py
+++ b/resources/lib/json_rpc.py
@@ -5,6 +5,7 @@ Collection of functions using the Kodi JSON RPC interface.
 See http://kodi.wiki/view/JSON-RPC_API
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from json import loads, dumps
 from xbmc import executeJSONRPC
 
@@ -85,7 +86,7 @@ def get_player_ids():
     Returns a list of all the active Kodi player ids (usually 3) as int
     """
     ret = []
-    for player in get_players().values():
+    for player in list(get_players().values()):
         ret.append(player['playerid'])
     return ret
 

--- a/resources/lib/kodi_constants.py
+++ b/resources/lib/kodi_constants.py
@@ -5,6 +5,7 @@ script.module.metadatautils
 kodi_constants.py
 Several common constants for use with Kodi json api
 '''
+from __future__ import unicode_literals
 FIELDS_BASE = ['dateadded', 'file', 'lastplayed', 'plot', 'title', 'art',
                'playcount']
 FIELDS_FILE = FIELDS_BASE + ['streamdetails', 'director', 'resume', 'runtime']

--- a/resources/lib/kodi_db/common.py
+++ b/resources/lib/kodi_db/common.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from threading import Lock
 
 from .. import db, path_ops
@@ -65,7 +66,7 @@ class KodiDBBase(object):
         """
         Pass in an artworks dict (see PlexAPI) to set an items artwork.
         """
-        for kodi_art, url in artworks.iteritems():
+        for kodi_art, url in artworks.items():
             self.add_art(url, kodi_id, kodi_type, kodi_art)
 
     @db.catch_operationalerrors
@@ -84,7 +85,7 @@ class KodiDBBase(object):
         """
         Pass in an artworks dict (see PlexAPI) to set an items artwork.
         """
-        for kodi_art, url in artworks.iteritems():
+        for kodi_art, url in artworks.items():
             self.modify_art(url, kodi_id, kodi_type, kodi_art)
 
     @db.catch_operationalerrors

--- a/resources/lib/kodi_db/video.py
+++ b/resources/lib/kodi_db/video.py
@@ -318,7 +318,7 @@ class KodiVideoDB(common.KodiDBBase):
         for the elmement kodi_id, kodi_type.
         Will also delete a freshly orphaned actor entry.
         """
-        for kind, people_list in people.iteritems():
+        for kind, people_list in people.items():
             self._add_people_kind(kodi_id, kodi_type, kind, people_list)
 
     @db.catch_operationalerrors
@@ -363,7 +363,7 @@ class KodiVideoDB(common.KodiDBBase):
         for kind, people_list in (people if people else
                                   {'actor': [],
                                    'director': [],
-                                   'writer': []}).iteritems():
+                                   'writer': []}).items():
             self._modify_people_kind(kodi_id, kodi_type, kind, people_list)
 
     @db.catch_operationalerrors

--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -58,7 +58,7 @@ class KodiMonitor(xbmc.Monitor):
         Called when a bunch of different stuff happens on the Kodi side
         """
         if data:
-            data = loads(data, 'utf-8')
+            data = loads(data)
             LOG.debug("Method: %s Data: %s", method, data)
 
         if method == "Player.OnPlay":

--- a/resources/lib/library_sync/common.py
+++ b/resources/lib/library_sync/common.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import next
+from builtins import object
 from logging import getLogger
 import xbmc
 

--- a/resources/lib/library_sync/fill_metadata_queue.py
+++ b/resources/lib/library_sync/fill_metadata_queue.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 from logging import getLogger
-from Queue import Empty
+from queue import Empty
 
 from . import common
 from ..plex_db import PlexDB

--- a/resources/lib/library_sync/fill_metadata_queue.py
+++ b/resources/lib/library_sync/fill_metadata_queue.py
@@ -30,8 +30,8 @@ class FillMetadataQueue(common.LibrarySyncMixin,
     def _process_section(self, section):
         # Initialize only once to avoid loosing the last value before we're
         # breaking the for loop
-        LOG.debug('Process section %s with %s items',
-                  section, section.number_of_items)
+#        LOG.debug('Process section %s with %s items',
+#                  section, section.number_of_items)
         count = 0
         with PlexDB(lock=False, copy=True) as plexdb:
             for xml in section.iterator:

--- a/resources/lib/library_sync/full_sync.py
+++ b/resources/lib/library_sync/full_sync.py
@@ -124,8 +124,8 @@ class FullSync(common.LibrarySyncMixin, bg.KillableThread):
             self.playstate_per_section(section)
 
     def playstate_per_section(self, section):
-        LOG.debug('Processing %s playstates for library section %s',
-                  section.number_of_items, section)
+#        LOG.debug('Processing %s playstates for library section %s',
+#                  section.number_of_items, section)
         try:
             with section.context(self.current_time) as context:
                 for xml in section.iterator:
@@ -181,8 +181,8 @@ class FullSync(common.LibrarySyncMixin, bg.KillableThread):
                         if section.number_of_items > 0:
                             self.processing_queue.add_section(section)
                             queue.put(section)
-                            LOG.debug('Put section in queue with %s items: %s',
-                                      section.number_of_items, section)
+#                            LOG.debug('Put section in queue with %s items: %s',
+#                                      section.number_of_items, section)
         except Exception:
             utils.ERROR(notify=True)
         finally:

--- a/resources/lib/library_sync/full_sync.py
+++ b/resources/lib/library_sync/full_sync.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
 from logging import getLogger
-import Queue
+import queue
 
 import xbmcgui
 
@@ -46,8 +49,8 @@ class FullSync(common.LibrarySyncMixin, bg.KillableThread):
         else:
             self.dialog = None
 
-        self.section_queue = Queue.Queue()
-        self.get_metadata_queue = Queue.Queue(maxsize=BACKLOG_QUEUE_SIZE)
+        self.section_queue = queue.Queue()
+        self.get_metadata_queue = queue.Queue(maxsize=BACKLOG_QUEUE_SIZE)
         self.processing_queue = bg.ProcessingQueue(maxsize=XML_QUEUE_SIZE)
         self.current_time = timing.plex_now()
         self.last_section = sections.Section()

--- a/resources/lib/library_sync/nodes.py
+++ b/resources/lib/library_sync/nodes.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
-import urllib
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+import urllib.request, urllib.parse, urllib.error
 import copy
 
 from ..utils import etree
@@ -56,7 +59,7 @@ NODE_TYPES = {
          {
               'mode': 'browseplex',
               'key': ('/library/sections/{self.section_id}&%s'
-                      % urllib.urlencode({'sort': 'rating:desc'})),
+                      % urllib.parse.urlencode({'sort': 'rating:desc'})),
               'section_id': '{self.section_id}'
          },
          v.CONTENT_TYPE_MOVIE,
@@ -84,7 +87,7 @@ NODE_TYPES = {
          {
               'mode': 'browseplex',
               'key': ('/library/sections/{self.section_id}&%s'
-                      % urllib.urlencode({'sort': 'random'})),
+                      % urllib.parse.urlencode({'sort': 'random'})),
               'section_id': '{self.section_id}'
          },
          v.CONTENT_TYPE_MOVIE,
@@ -154,7 +157,7 @@ NODE_TYPES = {
          {
               'mode': 'browseplex',
               'key': ('/library/sections/{self.section_id}&%s'
-                      % urllib.urlencode({'sort': 'rating:desc'})),
+                      % urllib.parse.urlencode({'sort': 'rating:desc'})),
               'section_id': '{self.section_id}'
          },
          v.CONTENT_TYPE_SHOW,
@@ -182,7 +185,7 @@ NODE_TYPES = {
          {
               'mode': 'browseplex',
               'key': ('/library/sections/{self.section_id}&%s'
-                      % urllib.urlencode({'sort': 'random'})),
+                      % urllib.parse.urlencode({'sort': 'random'})),
               'section_id': '{self.section_id}'
          },
          v.CONTENT_TYPE_SHOW,
@@ -192,7 +195,7 @@ NODE_TYPES = {
          {
               'mode': 'browseplex',
               'key': ('/library/sections/{self.section_id}/recentlyViewed&%s'
-                      % urllib.urlencode({'type': v.PLEX_TYPE_NUMBER_FROM_PLEX_TYPE[v.PLEX_TYPE_EPISODE]})),
+                      % urllib.parse.urlencode({'type': v.PLEX_TYPE_NUMBER_FROM_PLEX_TYPE[v.PLEX_TYPE_EPISODE]})),
               'section_id': '{self.section_id}'
          },
          v.CONTENT_TYPE_EPISODE,
@@ -236,7 +239,7 @@ def node_pms(section, node_name, args):
     else:
         folder = False
     xml = etree.Element('node',
-                        attrib={'order': unicode(section.order),
+                        attrib={'order': str(section.order),
                                 'type': 'folder' if folder else 'filter'})
     etree.SubElement(xml, 'label').text = node_name
     etree.SubElement(xml, 'icon').text = ICON_PATH
@@ -249,7 +252,7 @@ def node_ondeck(section, node_name):
     """
     For movies only - returns in-progress movies sorted by last played
     """
-    xml = etree.Element('node', attrib={'order': unicode(section.order),
+    xml = etree.Element('node', attrib={'order': str(section.order),
                                         'type': 'filter'})
     etree.SubElement(xml, 'match').text = 'all'
     rule = etree.SubElement(xml, 'rule', attrib={'field': 'tag',
@@ -270,7 +273,7 @@ def node_ondeck(section, node_name):
 
 def node_recent(section, node_name):
     xml = etree.Element('node',
-                        attrib={'order': unicode(section.order),
+                        attrib={'order': str(section.order),
                                 'type': 'filter'})
     etree.SubElement(xml, 'match').text = 'all'
     rule = etree.SubElement(xml, 'rule', attrib={'field': 'tag',
@@ -299,7 +302,7 @@ def node_recent(section, node_name):
 
 
 def node_all(section, node_name):
-    xml = etree.Element('node', attrib={'order': unicode(section.order),
+    xml = etree.Element('node', attrib={'order': str(section.order),
                                         'type': 'filter'})
     etree.SubElement(xml, 'match').text = 'all'
     rule = etree.SubElement(xml, 'rule', attrib={'field': 'tag',
@@ -316,7 +319,7 @@ def node_all(section, node_name):
 
 
 def node_recommended(section, node_name):
-    xml = etree.Element('node', attrib={'order': unicode(section.order),
+    xml = etree.Element('node', attrib={'order': str(section.order),
                                         'type': 'filter'})
     etree.SubElement(xml, 'match').text = 'all'
     rule = etree.SubElement(xml, 'rule', attrib={'field': 'tag',
@@ -337,7 +340,7 @@ def node_recommended(section, node_name):
 
 
 def node_genres(section, node_name):
-    xml = etree.Element('node', attrib={'order': unicode(section.order),
+    xml = etree.Element('node', attrib={'order': str(section.order),
                                         'type': 'filter'})
     etree.SubElement(xml, 'match').text = 'all'
     rule = etree.SubElement(xml, 'rule', attrib={'field': 'tag',
@@ -355,7 +358,7 @@ def node_genres(section, node_name):
 
 
 def node_sets(section, node_name):
-    xml = etree.Element('node', attrib={'order': unicode(section.order),
+    xml = etree.Element('node', attrib={'order': str(section.order),
                                         'type': 'filter'})
     etree.SubElement(xml, 'match').text = 'all'
     rule = etree.SubElement(xml, 'rule', attrib={'field': 'tag',
@@ -374,7 +377,7 @@ def node_sets(section, node_name):
 
 
 def node_random(section, node_name):
-    xml = etree.Element('node', attrib={'order': unicode(section.order),
+    xml = etree.Element('node', attrib={'order': str(section.order),
                                         'type': 'filter'})
     etree.SubElement(xml, 'match').text = 'all'
     rule = etree.SubElement(xml, 'rule', attrib={'field': 'tag',
@@ -392,7 +395,7 @@ def node_random(section, node_name):
 
 
 def node_lastplayed(section, node_name):
-    xml = etree.Element('node', attrib={'order': unicode(section.order),
+    xml = etree.Element('node', attrib={'order': str(section.order),
                                         'type': 'filter'})
     etree.SubElement(xml, 'match').text = 'all'
     rule = etree.SubElement(xml, 'rule', attrib={'field': 'tag',

--- a/resources/lib/library_sync/process_metadata.py
+++ b/resources/lib/library_sync/process_metadata.py
@@ -28,7 +28,7 @@ class ProcessMetadataThread(common.LibrarySyncMixin,
         if section != self.last_section:
             if self.last_section:
                 self.finish_last_section()
-            LOG.debug('Start or continue processing section %s', section)
+#            LOG.debug('Start or continue processing section %s', section)
             self.last_section = section
             # Warn the user for this new section if we cannot access a file
             app.SYNC.path_verified = False
@@ -44,8 +44,8 @@ class ProcessMetadataThread(common.LibrarySyncMixin,
                 # Set the new time mark for the next delta sync
                 plexdb.update_section_last_sync(self.last_section.section_id,
                                                 self.current_time)
-            LOG.info('Finished processing section successfully: %s',
-                     self.last_section)
+#            LOG.info('Finished processing section successfully: %s',
+#                     self.last_section)
         elif self.last_section and not self.last_section.sync_successful:
             LOG.warn('Sync not successful for section %s', self.last_section)
             self.successful = False

--- a/resources/lib/library_sync/sections.py
+++ b/resources/lib/library_sync/sections.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
+from builtins import range
+from builtins import object
 from logging import getLogger
 import copy
 
@@ -98,7 +101,7 @@ class Section(object):
                 "}}").format(self=self).encode('utf-8')
     __str__ = __repr__
 
-    def __nonzero__(self):
+    def __bool__(self):
         return (self.section_id is not None and
                 self.name is not None and
                 self.section_type is not None)
@@ -236,7 +239,7 @@ class Section(object):
             {key: '{self.<Section attribute>}'}
         """
         args = copy.deepcopy(args)
-        for key, value in args.iteritems():
+        for key, value in args.items():
             args[key] = value.format(self=self)
         return utils.extend_url('plugin://%s' % v.ADDON_ID, args)
 
@@ -265,7 +268,7 @@ class Section(object):
             args = {
                 'mode': 'browseplex',
                 'key': '/library/sections/%s' % self.section_id,
-                'section_id': unicode(self.section_id)
+                'section_id': str(self.section_id)
             }
             if not self.sync_to_kodi:
                 args['synched'] = 'false'
@@ -276,7 +279,7 @@ class Section(object):
             args = {
                 'mode': 'browseplex',
                 'key': '/library/sections/%s/all' % self.section_id,
-                'section_id': unicode(self.section_id)
+                'section_id': str(self.section_id)
             }
             if not self.sync_to_kodi:
                 args['synched'] = 'false'
@@ -318,7 +321,7 @@ class Section(object):
         if not path_ops.exists(path_ops.path.join(self.path, 'index.xml')):
             LOG.debug('Creating index.xml for section %s', self.name)
             xml = etree.Element('node',
-                                attrib={'order': unicode(self.order)})
+                                attrib={'order': str(self.order)})
             etree.SubElement(xml, 'label').text = self.name
             etree.SubElement(xml, 'icon').text = self.icon or nodes.ICON_PATH
             self._write_xml(xml, 'index.xml')
@@ -705,7 +708,7 @@ def _clear_window_vars(index):
     utils.window('%s.path' % node, clear=True)
     utils.window('%s.id' % node, clear=True)
     # Just clear everything here, ignore the plex_type
-    for typus in (x[0] for y in nodes.NODE_TYPES.values() for x in y):
+    for typus in (x[0] for y in list(nodes.NODE_TYPES.values()) for x in y):
         for kind in WINDOW_ARGS:
             node = 'Plex.nodes.%s.%s.%s' % (index, typus, kind)
             utils.window(node, clear=True)

--- a/resources/lib/library_sync/sections.py
+++ b/resources/lib/library_sync/sections.py
@@ -637,7 +637,7 @@ def sync_from_pms(parent_self, pick_libraries=False):
         return _sync_from_pms(pick_libraries)
     finally:
         SHOULD_CANCEL = None
-        LOG.info('Done synching sections from the PMS: %s', app.SYNC.sections)
+#        LOG.info('Done synching sections from the PMS: %s', app.SYNC.sections)
 
 
 def _sync_from_pms(pick_libraries):

--- a/resources/lib/library_sync/websocket.py
+++ b/resources/lib/library_sync/websocket.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
 from logging import getLogger
 
 from .common import update_kodi_library, PLAYLIST_SYNC_ENABLED
@@ -160,7 +161,7 @@ def store_timeline_message(data):
             continue
         status = int(message['state'])
         if typus == 'playlist' and PLAYLIST_SYNC_ENABLED:
-            playlists.websocket(plex_id=unicode(message['itemID']),
+            playlists.websocket(plex_id=str(message['itemID']),
                                 status=status)
         elif status == 9:
             # Immediately and always process deletions (as the PMS will

--- a/resources/lib/loghandler.py
+++ b/resources/lib/loghandler.py
@@ -19,13 +19,11 @@ def try_encode(uniString, encoding='utf-8'):
     fails with e.g. Android TV's Python, which does not accept arguments for
     string.encode()
     """
-    if isinstance(uniString, str):
-        # already encoded
-        return uniString
-    try:
-        uniString = uniString.encode(encoding, "ignore")
-    except TypeError:
-        uniString = uniString.encode()
+    if not isinstance(uniString, str):
+        try:
+            uniString = uniString.decode(encoding, "ignore")
+        except TypeError:
+            uniString = uniString.decode()
     return uniString
 
 
@@ -38,11 +36,9 @@ def config():
 class LogHandler(logging.StreamHandler):
     def __init__(self):
         logging.StreamHandler.__init__(self)
-        self.setFormatter(logging.Formatter(fmt=b"%(name)s: %(message)s"))
+        self.setFormatter(logging.Formatter(fmt="%(name)s: %(message)s"))
 
     def emit(self, record):
-        if isinstance(record.msg, str):
-            record.msg = record.msg.encode('utf-8')
         try:
             xbmc.log(self.format(record), level=LEVELS[record.levelno])
         except UnicodeEncodeError:

--- a/resources/lib/loghandler.py
+++ b/resources/lib/loghandler.py
@@ -41,7 +41,7 @@ class LogHandler(logging.StreamHandler):
         self.setFormatter(logging.Formatter(fmt=b"%(name)s: %(message)s"))
 
     def emit(self, record):
-        if isinstance(record.msg, unicode):
+        if isinstance(record.msg, str):
             record.msg = record.msg.encode('utf-8')
         try:
             xbmc.log(self.format(record), level=LEVELS[record.levelno])

--- a/resources/lib/migration.py
+++ b/resources/lib/migration.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
 from logging import getLogger
 
 from . import variables as v

--- a/resources/lib/path_ops.py
+++ b/resources/lib/path_ops.py
@@ -58,7 +58,7 @@ def translate_path(path):
     -> '/home/user/XBMC/UserData/script_data' on Linux.
     """
     translated = xbmc.translatePath(path.encode(KODI_ENCODING, 'strict'))
-    return translated.decode(KODI_ENCODING, 'strict')
+    return translated
 
 
 def exists(path):

--- a/resources/lib/pathtools/path.py
+++ b/resources/lib/pathtools/path.py
@@ -38,7 +38,9 @@ Functions
 .. autofunction:: real_absolute_path
 .. autofunction:: parent_dir_path
 """
+from __future__ import unicode_literals
 
+from builtins import next
 import os.path
 from functools import partial
 
@@ -72,7 +74,7 @@ def get_dir_walker(recursive, topdown=True, followlinks=False):
             try:
                 yield next(os.walk(path, topdown=topdown, followlinks=followlinks))
             except NameError:
-                yield os.walk(path, topdown=topdown, followlinks=followlinks).next() #IGNORE:E1101
+                yield next(os.walk(path, topdown=topdown, followlinks=followlinks)) #IGNORE:E1101
     return walk
 
 

--- a/resources/lib/pathtools/patterns.py
+++ b/resources/lib/pathtools/patterns.py
@@ -33,7 +33,9 @@ Functions
 .. autofunction:: match_path_against
 .. autofunction:: filter_paths
 """
+from __future__ import unicode_literals
 
+from builtins import map
 from fnmatch import fnmatch, fnmatchcase
 
 __all__ = ['match_path',

--- a/resources/lib/pathtools/version.py
+++ b/resources/lib/pathtools/version.py
@@ -22,6 +22,7 @@
 
 # When updating this version number, please update the
 # ``docs/source/global.rst.inc`` file as well.
+from __future__ import unicode_literals
 VERSION_MAJOR = 0
 VERSION_MINOR = 1
 VERSION_BUILD = 1

--- a/resources/lib/playback.py
+++ b/resources/lib/playback.py
@@ -4,6 +4,9 @@
 Used to kick off Kodi playback
 """
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 from logging import getLogger
 from threading import Thread
 import datetime
@@ -302,7 +305,7 @@ def resume_dialog(resume):
     resume = datetime.timedelta(seconds=resume)
     LOG.debug('Showing PKC resume dialog for resume: %s', resume)
     answ = utils.dialog('contextmenu',
-                        [utils.lang(12022).replace('{0:s}', '{0}').format(unicode(resume)),
+                        [utils.lang(12022).replace('{0:s}', '{0}').format(str(resume)),
                          utils.lang(12021)])
     if answ == -1:
         return

--- a/resources/lib/playlist_func.py
+++ b/resources/lib/playlist_func.py
@@ -4,6 +4,7 @@
 Collection of functions associated with Kodi and Plex playlists and playqueues
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 
 from .plex_api import API

--- a/resources/lib/playlist_func.py
+++ b/resources/lib/playlist_func.py
@@ -88,7 +88,6 @@ class Playqueue_Object(object):
                 "'repeat': {self.repeat}, "
                 "'kodi_playlist_playback': {self.kodi_playlist_playback}, "
                 "'pkc_edit': {self.pkc_edit}, ".format(self=self))
-        answ = answ.encode('utf-8')
         # Since list.__repr__ will return string, not unicode
         return answ + "'items': {self.items}}}".format(self=self)
 

--- a/resources/lib/playlist_func.py
+++ b/resources/lib/playlist_func.py
@@ -90,7 +90,7 @@ class Playqueue_Object(object):
                 "'pkc_edit': {self.pkc_edit}, ".format(self=self))
         answ = answ.encode('utf-8')
         # Since list.__repr__ will return string, not unicode
-        return answ + b"'items': {self.items}}}".format(self=self)
+        return answ + "'items': {self.items}}}".format(self=self)
 
     def __str__(self):
         return self.__repr__()

--- a/resources/lib/playlists/__init__.py
+++ b/resources/lib/playlists/__init__.py
@@ -293,10 +293,10 @@ def sync_kodi_playlist(path):
     bool
         True if we should sync this Kodi playlist to Plex, False otherwise
     """
-    if path.startswith(v.PLAYLIST_PATH_MIXED):
+    if path.startswith(v.PLAYLIST_PATH_MIXED.encode('utf-8')):
         return False
     try:
-        extension = path.rsplit('.', 1)[1].lower()
+        extension = path.decode().rsplit('.', 1)[1].lower()
     except IndexError:
         return False
     if extension not in SUPPORTED_FILETYPES:

--- a/resources/lib/playlists/common.py
+++ b/resources/lib/playlists/common.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 from logging import getLogger
-import Queue
+import queue
 import time
 import os
 import hashlib
@@ -188,7 +191,7 @@ class PlaylistObserver(Observer):
         while time.time() - start < timeout:
             try:
                 new_event, new_watch = event_queue.get(block=False)
-            except Queue.Empty:
+            except queue.Empty:
                 app.APP.monitor.waitForAbort(0.2)
             else:
                 event_queue.task_done()

--- a/resources/lib/playlists/db.py
+++ b/resources/lib/playlists/db.py
@@ -5,6 +5,7 @@ Synced playlists are stored in our plex.db. Interact with it through this
 module
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import next
 from logging import getLogger
 
 from .common import Playlist, PlaylistError

--- a/resources/lib/playlists/pms.py
+++ b/resources/lib/playlists/pms.py
@@ -5,6 +5,7 @@ Functions to communicate with the currently connected PMS in order to
 manipulate playlists
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
 from logging import getLogger
 
 from .common import PlaylistError
@@ -108,7 +109,7 @@ def add_items(playlist, plex_ids):
         'smart': 0,
         'uri': ('server://%s/com.plexapp.plugins.library/library/metadata/%s'
                 % (app.CONN.machine_identifier,
-                   ','.join(unicode(x) for x in plex_ids)))
+                   ','.join(str(x) for x in plex_ids)))
     }
     xml = DU().downloadUrl(url='{server}/playlists/',
                            action_type='POST',

--- a/resources/lib/playqueue.py
+++ b/resources/lib/playqueue.py
@@ -4,6 +4,7 @@
 Monitors the Kodi playqueue and adjusts the Plex playqueue accordingly
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import range
 from logging import getLogger
 import copy
 

--- a/resources/lib/plex_api/artwork.py
+++ b/resources/lib/plex_api/artwork.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
+from builtins import object
 from logging import getLogger
 from re import sub
 
@@ -70,7 +72,7 @@ class Artwork(object):
             # either the season or the show
             return artworks
         for kodi_artwork, plex_artwork in \
-                v.KODI_TO_PLEX_ARTWORK_EPISODE.iteritems():
+                v.KODI_TO_PLEX_ARTWORK_EPISODE.items():
             art = self.one_artwork(plex_artwork)
             if art:
                 artworks[kodi_artwork] = art
@@ -108,7 +110,7 @@ class Artwork(object):
                 with KodiMusicDB(lock=False) as kodidb:
                     return kodidb.get_art(kodi_id, kodi_type)
 
-        for kodi_artwork, plex_artwork in v.KODI_TO_PLEX_ARTWORK.iteritems():
+        for kodi_artwork, plex_artwork in v.KODI_TO_PLEX_ARTWORK.items():
             art = self.one_artwork(plex_artwork)
             if art:
                 artworks[kodi_artwork] = art

--- a/resources/lib/plex_api/base.py
+++ b/resources/lib/plex_api/base.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
+from builtins import object
 from logging import getLogger
 from re import sub
 
@@ -348,9 +350,9 @@ class Base(object):
             total = int(self.xml.attrib['leafCount'])
             watched = int(self.xml.attrib['viewedLeafCount'])
             return {
-                'totalepisodes': unicode(total),
-                'watchedepisodes': unicode(watched),
-                'unwatchedepisodes': unicode(total - watched)
+                'totalepisodes': str(total),
+                'watchedepisodes': str(watched),
+                'unwatchedepisodes': str(total - watched)
             }
         except (KeyError, TypeError):
             pass

--- a/resources/lib/plex_api/file.py
+++ b/resources/lib/plex_api/file.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
 
+from builtins import object
 from .. import utils, variables as v, app
 
 

--- a/resources/lib/plex_api/media.py
+++ b/resources/lib/plex_api/media.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 
 from ..utils import cast

--- a/resources/lib/plex_api/playback.py
+++ b/resources/lib/plex_api/playback.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
 
+from builtins import object
 from ..utils import cast
 
 

--- a/resources/lib/plex_api/user.py
+++ b/resources/lib/plex_api/user.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
 
+from builtins import object
 from ..utils import cast
 from .. import timing, variables as v, app
 

--- a/resources/lib/plex_companion.py
+++ b/resources/lib/plex_companion.py
@@ -4,9 +4,11 @@
 The Plex Companion master python file
 """
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 from logging import getLogger
 from threading import Thread
-from Queue import Empty
+from queue import Empty
 from socket import SHUT_RDWR
 from xbmc import executebuiltin
 

--- a/resources/lib/plex_db/common.py
+++ b/resources/lib/plex_db/common.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from threading import Lock
 
 from .. import db, variables as v

--- a/resources/lib/plex_db/movies.py
+++ b/resources/lib/plex_db/movies.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from .. import variables as v
 
 

--- a/resources/lib/plex_db/music.py
+++ b/resources/lib/plex_db/music.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from .. import variables as v
 
 

--- a/resources/lib/plex_db/playlists.py
+++ b/resources/lib/plex_db/playlists.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 
+from builtins import object
 class Playlists(object):
     def playlist_ids(self):
         """

--- a/resources/lib/plex_db/sections.py
+++ b/resources/lib/plex_db/sections.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 
+from builtins import object
 class Sections(object):
     def all_sections(self):
         """

--- a/resources/lib/plex_db/tvshows.py
+++ b/resources/lib/plex_db/tvshows.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from .. import variables as v
 
 

--- a/resources/lib/plex_functions.py
+++ b/resources/lib/plex_functions.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from builtins import object
 from logging import getLogger
 from ast import literal_eval
 from copy import deepcopy
@@ -326,7 +331,7 @@ def _pms_list_from_plex_tv(token):
         LOG.error('Could not get list of PMS from plex.tv')
         return []
 
-    from Queue import Queue
+    from queue import Queue
     queue = Queue()
     thread_queue = []
 

--- a/resources/lib/plex_tv.py
+++ b/resources/lib/plex_tv.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 from logging import getLogger
 import time
 import threading

--- a/resources/lib/plexbmchelper/httppersist.py
+++ b/resources/lib/plexbmchelper/httppersist.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 from logging import getLogger
-import httplib
+import http.client
 import traceback
 import string
 import errno
@@ -15,7 +19,7 @@ LOG = getLogger('PLEX.httppersist')
 ###############################################################################
 
 
-class RequestMgr:
+class RequestMgr(object):
     def __init__(self):
         self.conns = {}
 
@@ -23,9 +27,9 @@ class RequestMgr:
         conn = self.conns.get(protocol + host + str(port), False)
         if not conn:
             if protocol == "https":
-                conn = httplib.HTTPSConnection(host, port)
+                conn = http.client.HTTPSConnection(host, port)
             else:
-                conn = httplib.HTTPConnection(host, port)
+                conn = http.client.HTTPConnection(host, port)
             self.conns[protocol + host + str(port)] = conn
         return conn
 
@@ -36,7 +40,7 @@ class RequestMgr:
             self.conns.pop(protocol + host + str(port), None)
 
     def dumpConnections(self):
-        for conn in self.conns.values():
+        for conn in list(self.conns.values()):
             conn.close()
         self.conns = {}
 

--- a/resources/lib/plexbmchelper/listener.py
+++ b/resources/lib/plexbmchelper/listener.py
@@ -4,10 +4,12 @@
 Plex Companion listener
 """
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 from logging import getLogger
 from re import sub
-from SocketServer import ThreadingMixIn
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from socketserver import ThreadingMixIn
+from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from .. import utils, companion, json_rpc as js, clientinfo, variables as v
 from .. import app

--- a/resources/lib/plexbmchelper/plexgdm.py
+++ b/resources/lib/plexbmchelper/plexgdm.py
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 MA 02110-1301, USA.
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
+from builtins import object
 import logging
 import socket
 import threading
@@ -39,7 +41,7 @@ log = logging.getLogger('PLEX.plexgdm')
 ###############################################################################
 
 
-class plexgdm:
+class plexgdm(object):
 
     def __init__(self):
         self.discover_message = 'M-SEARCH * HTTP/1.0'

--- a/resources/lib/plexbmchelper/plexgdm.py
+++ b/resources/lib/plexbmchelper/plexgdm.py
@@ -163,15 +163,15 @@ class plexgdm(object):
             except socket.error:
                 pass
             else:
-                if "M-SEARCH * HTTP/1." in data:
+                if b"M-SEARCH * HTTP/1." in data:
                     log.debug("Detected client discovery request from %s. "
                               " Replying" % str(addr))
                     try:
-                        update_sock.sendto("HTTP/1.0 200 OK\n%s"
-                                           % self.client_data,
-                                           addr)
-                    except Exception:
-                        log.error("Unable to send client update message")
+                        reg_data = "HTTP/1.0 200 OK\n%s" % self.client_data
+                        log.debug(reg_data)
+                        update_sock.sendto(reg_data.encode(), addr)
+                    except Exception as err:
+                        log.error("Unable to send 200 client update message\n%s" % err)
 
                     log.debug("Sending registration data HTTP/1.0 200 OK")
                     self.client_registered = True
@@ -182,7 +182,7 @@ class plexgdm(object):
         log.debug("Sending registration data: BYE %s\n%s"
                   % (self.client_header, self.client_data))
         try:
-            update_sock.sendto("BYE %s\n%s"
+            update_sock.sendto(b"BYE %s\n%s"
                                % (self.client_header, self.client_data),
                                self.client_register_group)
         except Exception:

--- a/resources/lib/plexbmchelper/subscribers.py
+++ b/resources/lib/plexbmchelper/subscribers.py
@@ -5,6 +5,10 @@ Manages getting playstate from Kodi and sending it to the PMS as well as
 subscribed Plex Companion clients.
 """
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 from logging import getLogger
 from threading import Thread
 
@@ -174,7 +178,7 @@ class SubscriptionMgr(object):
         Returns the string 'key1="value1" key2="value2" ...' for dictionary
         """
         answ = ''
-        for key, value in dictionary.iteritems():
+        for key, value in dictionary.items():
             answ += '%s="%s" ' % (key, value)
         return answ
 
@@ -317,7 +321,7 @@ class SubscriptionMgr(object):
         Hence we'd have a missmatch between the state.PLAYER_STATES and our
         playqueues.
         """
-        for player in players.values():
+        for player in list(players.values()):
             info = app.PLAYSTATE.player_states[player['playerid']]
             playqueue = PQ.PLAYQUEUES[player['playerid']]
             position = self._get_correct_position(info, playqueue)
@@ -342,7 +346,7 @@ class SubscriptionMgr(object):
             # Get all the active/playing Kodi players (video, audio, pictures)
             players = js.get_players()
             # Update the PKC info with what's playing on the Kodi side
-            for player in players.values():
+            for player in list(players.values()):
                 update_player_info(player['playerid'])
             # Check whether we can use the CURRENT info or whether PKC is still
             # initializing
@@ -352,12 +356,12 @@ class SubscriptionMgr(object):
             self._notify_server(players)
             if self.subscribers:
                 msg = self.msg(players)
-                for subscriber in self.subscribers.values():
+                for subscriber in list(self.subscribers.values()):
                     subscriber.send_update(msg)
             self.lastplayers = players
 
     def _notify_server(self, players):
-        for typus, player in players.iteritems():
+        for typus, player in players.items():
             self._send_pms_notification(
                 player['playerid'], self._get_pms_params(player['playerid']))
             try:
@@ -365,7 +369,7 @@ class SubscriptionMgr(object):
             except KeyError:
                 pass
         # Process the players we have left (to signal a stop)
-        for player in self.lastplayers.values():
+        for player in list(self.lastplayers.values()):
             self.last_params['state'] = 'stopped'
             self._send_pms_notification(player['playerid'], self.last_params)
 
@@ -442,13 +446,13 @@ class SubscriptionMgr(object):
         (Calls the cleanup() method of the subscriber)
         """
         with app.APP.lock_subscriber:
-            for subscriber in self.subscribers.values():
+            for subscriber in list(self.subscribers.values()):
                 if subscriber.uuid == uuid or subscriber.host == uuid:
                     subscriber.cleanup()
                     del self.subscribers[subscriber.uuid]
 
     def _cleanup(self):
-        for subscriber in self.subscribers.values():
+        for subscriber in list(self.subscribers.values()):
             if subscriber.age > 30:
                 subscriber.cleanup()
                 del self.subscribers[subscriber.uuid]

--- a/resources/lib/service_entry.py
+++ b/resources/lib/service_entry.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import object
 import logging
 import sys
 import xbmc

--- a/resources/lib/sync.py
+++ b/resources/lib/sync.py
@@ -236,7 +236,7 @@ class Sync(backgroundthread.KillableThread):
                     # See if there is a PMS message we need to handle
                     try:
                         message = queue.get(block=False)
-                    except backgroundthread.Queue.Empty:
+                    except backgroundthread.queue.Empty:
                         pass
                     # Got a message from PMS; process it
                     else:

--- a/resources/lib/tools/platform.py
+++ b/resources/lib/tools/platform.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 
+from __future__ import unicode_literals
 import sys
 
 PLATFORM_WINDOWS = 'windows'

--- a/resources/lib/tools/unicode_paths.py
+++ b/resources/lib/tools/unicode_paths.py
@@ -22,13 +22,14 @@
 # SOFTWARE.
 
 
+from __future__ import unicode_literals
 import sys
 
 from . import platform
 
 try:
     # Python 2
-    str_cls = unicode
+    str_cls = str
     bytes_cls = str
 except NameError:
     # Python 3

--- a/resources/lib/transfer.py
+++ b/resources/lib/transfer.py
@@ -5,6 +5,8 @@ Used to shovel data from separate Kodi Python instances to the main thread
 and vice versa.
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
+from builtins import object
 from logging import getLogger
 import json
 
@@ -33,15 +35,15 @@ def cast(func, value):
         return value
     elif func == bool:
         return bool(int(value))
-    elif func == unicode:
-        if isinstance(value, (int, long, float)):
-            return unicode(value)
-        elif isinstance(value, unicode):
+    elif func == str:
+        if isinstance(value, (int, float)):
+            return str(value)
+        elif isinstance(value, str):
             return value
         else:
             return value.decode('utf-8')
     elif func == str:
-        if isinstance(value, (int, long, float)):
+        if isinstance(value, (int, float)):
             return str(value)
         elif isinstance(value, str):
             return value
@@ -163,7 +165,7 @@ def convert_pkc_to_listitem(pkc_listitem):
         listitem.addStreamInfo(**stream)
     if data['art']:
         listitem.setArt(data['art'])
-    for key, value in data['property'].iteritems():
+    for key, value in data['property'].items():
         listitem.setProperty(key, cast(str, value))
     if data['subtitles']:
         listitem.setSubtitles(data['subtitles'])

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -410,7 +410,7 @@ def quote(s, safe='/'):
     if isinstance(s, str):
         s = s.encode('utf-8')
     s = urllib.parse.quote(s, safe.encode('utf-8'))
-    return s.decode('utf-8')
+    return urllib.parse.quote(s, safe.encode('utf-8'))
 
 
 def quote_plus(s, safe=''):
@@ -421,7 +421,7 @@ def quote_plus(s, safe=''):
     if isinstance(s, str):
         s = s.encode('utf-8')
     s = urllib.parse.quote_plus(s, safe.encode('utf-8'))
-    return s.decode('utf-8')
+    return urllib.parse.quote_plus(s, safe.encode('utf-8'))
 
 
 def unquote(s):
@@ -432,7 +432,7 @@ def unquote(s):
     if isinstance(s, str):
         s = s.encode('utf-8')
     s = urllib.parse.unquote(s)
-    return s.decode('utf-8')
+    return urllib.parse.unquote(s)
 
 
 def try_encode(input_str, encoding='utf-8'):

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -324,7 +324,7 @@ def extend_url(url, params):
     in unicode
     """
     params = encode_dict(params) if params else {}
-    params = urllib.parse.urlencode(params).decode('utf-8')
+    params = urllib.parse.urlencode(params)
     if '?' in url:
         return '%s&%s' % (url, params)
     else:

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -4,13 +4,17 @@
 Various functions and decorators for PKC
 """
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 from logging import getLogger
 from sqlite3 import OperationalError
 from datetime import datetime
 from unicodedata import normalize
 from threading import Lock
-import urllib
-import urlparse as _urlparse
+import urllib.request, urllib.parse, urllib.error
+import urllib.parse as _urlparse
 # Originally tried faster cElementTree, but does NOT work reliably with Kodi
 import xml.etree.ElementTree as etree
 # etree parse unsafe; make sure we're always receiving unicode
@@ -191,7 +195,7 @@ def dialog(typus, *args, **kwargs):
             '{warning}': xbmcgui.NOTIFICATION_WARNING,
             '{error}': xbmcgui.NOTIFICATION_ERROR
         }
-        for key, value in types.iteritems():
+        for key, value in types.items():
             kwargs['icon'] = kwargs['icon'].replace(key, value)
     if 'type' in kwargs:
         types = {
@@ -282,15 +286,15 @@ def cast(func, value):
         return value
     elif func == bool:
         return bool(int(value))
-    elif func == unicode:
-        if isinstance(value, (int, long, float)):
-            return unicode(value)
-        elif isinstance(value, unicode):
+    elif func == str:
+        if isinstance(value, (int, float)):
+            return str(value)
+        elif isinstance(value, str):
             return value
         else:
             return value.decode('utf-8')
     elif func == str:
-        if isinstance(value, (int, long, float)):
+        if isinstance(value, (int, float)):
             return str(value)
         elif isinstance(value, str):
             return value
@@ -320,7 +324,7 @@ def extend_url(url, params):
     in unicode
     """
     params = encode_dict(params) if params else {}
-    params = urllib.urlencode(params).decode('utf-8')
+    params = urllib.parse.urlencode(params).decode('utf-8')
     if '?' in url:
         return '%s&%s' % (url, params)
     else:
@@ -334,10 +338,10 @@ def encode_dict(dictionary):
 
     Useful for urllib.urlencode or urllib.(un)quote
     """
-    for key, value in dictionary.iteritems():
-        if isinstance(key, unicode):
+    for key, value in dictionary.items():
+        if isinstance(key, str):
             dictionary[key.encode('utf-8')] = dictionary.pop(key)
-        if isinstance(value, unicode):
+        if isinstance(value, str):
             dictionary[key] = value.encode('utf-8')
     return dictionary
 
@@ -348,11 +352,11 @@ def parse_qs(qs, keep_blank_values=0, strict_parsing=0):
     either as str or unicode
     Returns a dict with lists as values; all entires unicode
     """
-    if isinstance(qs, unicode):
+    if isinstance(qs, str):
         qs = qs.encode('utf-8')
     qs = _urlparse.parse_qs(qs, keep_blank_values, strict_parsing)
     return {k.decode('utf-8'): [e.decode('utf-8') for e in v]
-            for k, v in qs.iteritems()}
+            for k, v in qs.items()}
 
 
 def parse_qsl(qs, keep_blank_values=0, strict_parsing=0):
@@ -360,7 +364,7 @@ def parse_qsl(qs, keep_blank_values=0, strict_parsing=0):
     unicode-safe way to use urlparse.parse_qsl(). Pass in either str or unicode
     Returns a list of unicode tuples
     """
-    if isinstance(qs, unicode):
+    if isinstance(qs, str):
         qs = qs.encode('utf-8')
     qs = _urlparse.parse_qsl(qs, keep_blank_values, strict_parsing)
     return [(x.decode('utf-8'), y.decode('utf-8')) for (x, y) in qs]
@@ -371,7 +375,7 @@ def urlparse(url, scheme='', allow_fragments=True):
     unicode-safe way to use urlparse.urlparse(). Pass in either str or unicode
     CAREFUL: returns an encoded urlparse.ParseResult()!
     """
-    if isinstance(url, unicode):
+    if isinstance(url, str):
         url = url.encode('utf-8')
     return _urlparse.urlparse(url, scheme, allow_fragments)
 
@@ -387,7 +391,7 @@ def escape_path(path):
     you in trouble (e.g. '@')
     Returns the escaped path as unicode
     """
-    return urllib.quote(path.encode('utf-8'),
+    return urllib.parse.quote(path.encode('utf-8'),
                         safe=SAFE_URL_CHARACTERS).decode('utf-8')
 
 
@@ -396,9 +400,9 @@ def quote(s, safe='/'):
     unicode-safe way to use urllib.quote(). Pass in either str or unicode
     Returns unicode
     """
-    if isinstance(s, unicode):
+    if isinstance(s, str):
         s = s.encode('utf-8')
-    s = urllib.quote(s, safe.encode('utf-8'))
+    s = urllib.parse.quote(s, safe.encode('utf-8'))
     return s.decode('utf-8')
 
 
@@ -407,9 +411,9 @@ def quote_plus(s, safe=''):
     unicode-safe way to use urllib.quote(). Pass in either str or unicode
     Returns unicode
     """
-    if isinstance(s, unicode):
+    if isinstance(s, str):
         s = s.encode('utf-8')
-    s = urllib.quote_plus(s, safe.encode('utf-8'))
+    s = urllib.parse.quote_plus(s, safe.encode('utf-8'))
     return s.decode('utf-8')
 
 
@@ -418,9 +422,9 @@ def unquote(s):
     unicode-safe way to use urllib.unquote(). Pass in either str or unicode
     Returns unicode
     """
-    if isinstance(s, unicode):
+    if isinstance(s, str):
         s = s.encode('utf-8')
-    s = urllib.unquote(s)
+    s = urllib.parse.unquote(s)
     return s.decode('utf-8')
 
 
@@ -446,7 +450,7 @@ def try_decode(string, encoding='utf-8'):
     fails with e.g. Android TV's Python, which does not accept arguments for
     string.encode()
     """
-    if isinstance(string, unicode):
+    if isinstance(string, str):
         # already decoded
         return string
     try:
@@ -461,9 +465,9 @@ def slugify(text):
     Normalizes text (in unicode or string) to e.g. enable safe filenames.
     Returns unicode
     """
-    if not isinstance(text, unicode):
-        text = unicode(text)
-    return unicode(normalize('NFKD', text).encode('ascii', 'ignore'))
+    if not isinstance(text, str):
+        text = str(text)
+    return str(normalize('NFKD', text).encode('ascii', 'ignore'))
 
 
 def valid_filename(text):
@@ -507,7 +511,7 @@ def escape_html(string):
         '>': '&gt;',
         '&': '&amp;'
     }
-    for key, value in escapes.iteritems():
+    for key, value in escapes.items():
         string = string.replace(key, value)
     return string
 
@@ -654,7 +658,7 @@ def normalize_string(text):
     # Remove dots from the last character as windows can not have directories
     # with dots at the end
     text = text.rstrip('.')
-    text = try_encode(normalize('NFKD', unicode(text, 'utf-8')))
+    text = try_encode(normalize('NFKD', str(text, 'utf-8')))
 
     return text
 
@@ -677,7 +681,7 @@ def normalize_nodes(text):
     # Remove dots from the last character as windows can not have directories
     # with dots at the end
     text = text.rstrip('.')
-    text = normalize('NFKD', unicode(text, 'utf-8'))
+    text = normalize('NFKD', str(text, 'utf-8'))
     return text
 
 
@@ -900,7 +904,7 @@ class XmlKodiSetting(object):
         # Write new values
         element.text = value
         if attrib:
-            for key, attribute in attrib.iteritems():
+            for key, attribute in attrib.items():
                 element.set(key, attribute)
         return element
 
@@ -922,7 +926,7 @@ def process_method_on_list(method_to_run, items):
         pool.join()
     else:
         all_items = [method_to_run(item) for item in items]
-    all_items = filter(None, all_items)
+    all_items = [_f for _f in all_items if _f]
     return all_items
 
 

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -338,12 +338,19 @@ def encode_dict(dictionary):
 
     Useful for urllib.urlencode or urllib.(un)quote
     """
+    encoded_dictionary = {}
+
     for key, value in dictionary.items():
         if isinstance(key, str):
-            dictionary[key.encode('utf-8')] = dictionary.pop(key)
-        if isinstance(value, str):
-            dictionary[key] = value.encode('utf-8')
-    return dictionary
+            if isinstance(value, str):
+                encoded_dictionary[key.encode('utf-8')] = value.encode('utf-8')
+            else:
+                encoded_dictionary[key.encode('utf-8')] = value
+        elif isinstance(value, str):
+            encoded_dictionary[key] = value.encode('utf-8')
+        else:
+            encoded_dictionary[key] = value
+    return encoded_dictionary
 
 
 def parse_qs(qs, keep_blank_values=0, strict_parsing=0):
@@ -477,7 +484,7 @@ def valid_filename(text):
     # Get rid of all whitespace except a normal space
     text = re.sub(r'(?! )\s', '', text)
     # ASCII characters 0 to 31 (non-printable, just in case)
-    text = re.sub(u'[\x00-\x1f]', '', text)
+    text = re.sub('[\x00-\x1f]', '', text)
     if v.DEVICE == 'Windows':
         # Whitespace at the end of the filename is illegal
         text = text.strip()

--- a/resources/lib/variables.py
+++ b/resources/lib/variables.py
@@ -20,7 +20,7 @@ def try_decode(string, encoding='utf-8'):
     fails with e.g. Android TV's Python, which does not accept arguments for
     string.encode()
     """
-    if isinstance(string, unicode):
+    if isinstance(string, str):
         # already decoded
         return string
     try:

--- a/resources/lib/watchdog/events.py
+++ b/resources/lib/watchdog/events.py
@@ -84,7 +84,9 @@ Event Handler Classes
    :show-inheritance:
 
 """
+from __future__ import unicode_literals
 
+from builtins import object
 import os.path
 import logging
 import re

--- a/resources/lib/watchdog/observers/__init__.py
+++ b/resources/lib/watchdog/observers/__init__.py
@@ -53,6 +53,7 @@ Class          Platforms                        Note
 .. |Polling|     replace:: :class:`.polling.PollingObserver`
 
 """
+from __future__ import unicode_literals
 
 import warnings
 from ..utils import platform

--- a/resources/lib/watchdog/observers/api.py
+++ b/resources/lib/watchdog/observers/api.py
@@ -16,9 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, with_statement
 from builtins import object
-from __future__ import with_statement
 import threading
 from ..utils import BaseThread
 from ..utils.compat import queue

--- a/resources/lib/watchdog/observers/api.py
+++ b/resources/lib/watchdog/observers/api.py
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from builtins import object
 from __future__ import with_statement
 import threading
 from ..utils import BaseThread

--- a/resources/lib/watchdog/observers/fsevents.py
+++ b/resources/lib/watchdog/observers/fsevents.py
@@ -24,6 +24,7 @@
 """
 
 from __future__ import with_statement
+from __future__ import unicode_literals
 
 import sys
 import threading
@@ -150,7 +151,7 @@ class FSEventsObserver(BaseObserver):
     def schedule(self, event_handler, path, recursive=False):
         # Python 2/3 compat
         try:
-            str_class = unicode
+            str_class = str
         except NameError:
             str_class = str
 

--- a/resources/lib/watchdog/observers/fsevents2.py
+++ b/resources/lib/watchdog/observers/fsevents2.py
@@ -19,7 +19,11 @@
 :synopsis: FSEvents based emitter implementation.
 :platforms: Mac OS X
 """
+from __future__ import unicode_literals
 
+from builtins import hex
+from builtins import zip
+from builtins import object
 import os
 import logging
 import unicodedata

--- a/resources/lib/watchdog/observers/inotify.py
+++ b/resources/lib/watchdog/observers/inotify.py
@@ -68,6 +68,7 @@ Some extremely useful articles and documentation:
 """
 
 from __future__ import with_statement
+from __future__ import unicode_literals
 
 import os
 import threading

--- a/resources/lib/watchdog/observers/inotify_buffer.py
+++ b/resources/lib/watchdog/observers/inotify_buffer.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import logging
 from ..utils import BaseThread
 from ..utils.delayed_queue import DelayedQueue

--- a/resources/lib/watchdog/observers/inotify_c.py
+++ b/resources/lib/watchdog/observers/inotify_c.py
@@ -15,9 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals with_statement
 from builtins import object
-from __future__ import with_statement
 import os
 import errno
 import struct

--- a/resources/lib/watchdog/observers/inotify_c.py
+++ b/resources/lib/watchdog/observers/inotify_c.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import unicode_literals with_statement
+from __future__ import unicode_literals, with_statement
 from builtins import object
 import os
 import errno

--- a/resources/lib/watchdog/observers/inotify_c.py
+++ b/resources/lib/watchdog/observers/inotify_c.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from builtins import object
 from __future__ import with_statement
 import os
 import errno

--- a/resources/lib/watchdog/observers/kqueue.py
+++ b/resources/lib/watchdog/observers/kqueue.py
@@ -76,7 +76,9 @@ Collections and Utility Classes
 .. _Mac OS X File System Performance Guidelines: http://developer.apple.com/library/ios/#documentation/Performance/Conceptual/FileSystem/Articles/TrackingChanges.html#//apple_ref/doc/uid/20001993-CJBJFIDD
 
 """
+from __future__ import unicode_literals
 
+from builtins import object
 from __future__ import with_statement
 from ..utils import platform
 

--- a/resources/lib/watchdog/observers/polling.py
+++ b/resources/lib/watchdog/observers/polling.py
@@ -35,6 +35,7 @@ Classes
 """
 
 from __future__ import with_statement
+from __future__ import unicode_literals
 import os
 import threading
 from functools import partial

--- a/resources/lib/watchdog/observers/read_directory_changes.py
+++ b/resources/lib/watchdog/observers/read_directory_changes.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 from __future__ import with_statement
+from __future__ import unicode_literals
 
 import ctypes
 import threading

--- a/resources/lib/watchdog/observers/winapi.py
+++ b/resources/lib/watchdog/observers/winapi.py
@@ -36,6 +36,8 @@
 # Portions of this code were taken from pyfilesystem, which uses the above
 # new BSD license.
 
+from __future__ import unicode_literals
+from builtins import object
 from __future__ import with_statement
 
 import ctypes.wintypes
@@ -308,7 +310,7 @@ def read_directory_changes(handle, recursive):
 
     # Python 2/3 compat
     try:
-        int_class = long
+        int_class = int
     except NameError:
         int_class = int
     return event_buffer.raw, int_class(nbytes.value)

--- a/resources/lib/watchdog/tricks/__init__.py
+++ b/resources/lib/watchdog/tricks/__init__.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 
+from __future__ import unicode_literals
 import os
 import signal
 import subprocess

--- a/resources/lib/watchdog/utils/__init__.py
+++ b/resources/lib/watchdog/utils/__init__.py
@@ -30,6 +30,8 @@ Classes
    :inherited-members:
 
 """
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import sys
 import threading
@@ -39,7 +41,7 @@ from .compat import Event
 
 if sys.version_info[0] == 2 and platform.is_windows():
     # st_ino is not implemented in os.stat on this platform
-    import win32stat
+    from . import win32stat
     stat = win32stat.stat
 else:
     stat = os.stat

--- a/resources/lib/watchdog/utils/bricks.py
+++ b/resources/lib/watchdog/utils/bricks.py
@@ -35,7 +35,10 @@ Classes
 .. autoclass:: OrderedSet
 
 """
+from __future__ import unicode_literals
 
+from builtins import next
+from builtins import range
 import sys
 import collections
 from .compat import queue

--- a/resources/lib/watchdog/utils/compat.py
+++ b/resources/lib/watchdog/utils/compat.py
@@ -13,6 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 import sys
 
 __all__ = ['queue', 'Event']
@@ -20,7 +23,7 @@ __all__ = ['queue', 'Event']
 try:
     import queue
 except ImportError:
-    import Queue as queue
+    import queue as queue
 
 
 if sys.version_info < (2, 7):

--- a/resources/lib/watchdog/utils/decorators.py
+++ b/resources/lib/watchdog/utils/decorators.py
@@ -13,7 +13,9 @@ decorators:
 - attrs
 - deprecated
 """
+from __future__ import unicode_literals
 
+from builtins import zip
 import functools
 import warnings
 import threading

--- a/resources/lib/watchdog/utils/delayed_queue.py
+++ b/resources/lib/watchdog/utils/delayed_queue.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from builtins import object
 import time
 import threading
 from collections import deque

--- a/resources/lib/watchdog/utils/dirsnapshot.py
+++ b/resources/lib/watchdog/utils/dirsnapshot.py
@@ -43,7 +43,10 @@ Classes
    :show-inheritance:
 
 """
+from __future__ import unicode_literals
 
+from builtins import str
+from builtins import object
 import errno
 import os
 from stat import S_ISDIR

--- a/resources/lib/watchdog/utils/echo.py
+++ b/resources/lib/watchdog/utils/echo.py
@@ -32,6 +32,9 @@ Example:
   def my_function(args):
       pass
 """
+from __future__ import unicode_literals
+from builtins import map
+from builtins import zip
 import inspect
 import sys
 

--- a/resources/lib/watchdog/utils/event_backport.py
+++ b/resources/lib/watchdog/utils/event_backport.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 # Backport of Event from py2.7 (method wait in py2.6 returns None)
 
+from __future__ import unicode_literals
+from builtins import object
 from threading import Condition, Lock
 
 

--- a/resources/lib/watchdog/utils/importlib2.py
+++ b/resources/lib/watchdog/utils/importlib2.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # The MIT License (MIT)
 
 # Copyright (c) 2013 Peter M. Elias
@@ -31,7 +32,7 @@ def import_module(target, relative_to=None):
         relative_parts = relative_to.split('.')
         relative_to = '.'.join(relative_parts[:-(target_depth - 1) or None])
     if len(target_path) > 1:
-        relative_to = '.'.join(filter(None, [relative_to]) + target_path[:-1])
+        relative_to = '.'.join([_f for _f in [relative_to] if _f] + target_path[:-1])
         fromlist = target_path[-1:]
         target = fromlist[0]
     elif not relative_to:

--- a/resources/lib/watchdog/utils/platform.py
+++ b/resources/lib/watchdog/utils/platform.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 
+from __future__ import unicode_literals
 import sys
 
 PLATFORM_WINDOWS = 'windows'

--- a/resources/lib/watchdog/utils/unicode_paths.py
+++ b/resources/lib/watchdog/utils/unicode_paths.py
@@ -22,13 +22,14 @@
 # SOFTWARE.
 
 
+from __future__ import unicode_literals
 import sys
 
 from . import platform
 
 try:
     # Python 2
-    str_cls = unicode
+    str_cls = str
     bytes_cls = str
 except NameError:
     # Python 3

--- a/resources/lib/watchdog/utils/win32stat.py
+++ b/resources/lib/watchdog/utils/win32stat.py
@@ -24,7 +24,10 @@ Functions
 .. autofunction:: stat
 
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from past.utils import old_div
 import ctypes
 import ctypes.wintypes
 import stat as stdstat
@@ -99,7 +102,7 @@ def _to_mode(attr):
 
 def _to_unix_time(ft):
     t = (ft.dwHighDateTime) << 32 | ft.dwLowDateTime
-    return (t / 10000000) - 11644473600
+    return (old_div(t, 10000000)) - 11644473600
 
 def stat(path):
     hfile = CreateFile(path,

--- a/resources/lib/watchdog/version.py
+++ b/resources/lib/watchdog/version.py
@@ -19,6 +19,7 @@
 
 # When updating this version number, please update the
 # ``docs/source/global.rst.inc`` file as well.
+from __future__ import unicode_literals
 VERSION_MAJOR = 0
 VERSION_MINOR = 8
 VERSION_BUILD = 3

--- a/resources/lib/watchdog/watchmedo.py
+++ b/resources/lib/watchdog/watchmedo.py
@@ -21,7 +21,10 @@
 :author: yesudeep@google.com (Yesudeep Mangalapilly)
 :synopsis: ``watchmedo`` shell script utility.
 """
+from __future__ import unicode_literals
 
+from future import standard_library
+standard_library.install_aliases()
 import os.path
 import sys
 import yaml
@@ -29,10 +32,10 @@ import time
 import logging
 
 try:
-    from cStringIO import StringIO
+    from io import StringIO
 except ImportError:
     try:
-        from StringIO import StringIO
+        from io import StringIO
     except ImportError:
         from io import StringIO
 

--- a/resources/lib/websocket.py
+++ b/resources/lib/websocket.py
@@ -20,6 +20,13 @@ Copyright (C) 2010 Hiroki Ohtani(liris)
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 """
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import chr
+from builtins import range
+from builtins import object
 import socket
 
 try:
@@ -35,7 +42,7 @@ except ImportError:
 
     HAVE_SSL = False
 
-from urlparse import urlparse
+from urllib.parse import urlparse
 import os
 import array
 import struct
@@ -228,7 +235,7 @@ def create_connection(url, timeout=None, **options):
 
 
 _MAX_INTEGER = (1 << 32) - 1
-_AVAILABLE_KEY_CHARS = range(0x21, 0x2f + 1) + range(0x3a, 0x7e + 1)
+_AVAILABLE_KEY_CHARS = list(range(0x21, 0x2f + 1)) + list(range(0x3a, 0x7e + 1))
 _MAX_CHAR_BYTE = (1 << 8) - 1
 
 # ref. Websocket gets an update, and it breaks stuff.
@@ -308,7 +315,7 @@ class ABNF(object):
 
         opcode: operation code. please see OPCODE_XXX.
         """
-        if opcode == ABNF.OPCODE_TEXT and isinstance(data, unicode):
+        if opcode == ABNF.OPCODE_TEXT and isinstance(data, str):
             data = utils.try_encode(data)
         # mask must be set if send data from client
         return ABNF(1, 0, 0, 0, opcode, 1, data)
@@ -358,7 +365,7 @@ class ABNF(object):
         """
         _m = array.array("B", mask_key)
         _d = array.array("B", data)
-        for i in xrange(len(_d)):
+        for i in range(len(_d)):
             _d[i] ^= _m[i % 4]
         return _d.tostring()
 
@@ -529,7 +536,7 @@ class WebSocket(object):
 
     @staticmethod
     def _validate_header(headers, key):
-        for k, v in _HEADERS_TO_CHECK.iteritems():
+        for k, v in _HEADERS_TO_CHECK.items():
             r = headers.get(k, None)
             if not r:
                 return False
@@ -882,11 +889,11 @@ class WebSocketApp(object):
                     if data is None or self.keep_running is False:
                         break
                     self._callback(self.on_message, data)
-                except Exception, e:
+                except Exception as e:
                     if "timed out" not in e.args[0]:
                         raise e
 
-        except Exception, e:
+        except Exception as e:
             self._callback(self.on_error, e)
         finally:
             if thread:
@@ -899,7 +906,7 @@ class WebSocketApp(object):
         if callback:
             try:
                 callback(self, *args)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(e)
                 _, _, tb = sys.exc_info()
                 traceback.print_tb(tb)

--- a/resources/lib/websocket.py
+++ b/resources/lib/websocket.py
@@ -352,7 +352,7 @@ class ABNF(object):
 
     def _get_masked(self, mask_key):
         s = ABNF.mask(mask_key, self.data)
-        return mask_key + "".join(s)
+        return mask_key.decode() + "".join(s)
 
     @staticmethod
     def mask(mask_key, data):

--- a/resources/lib/websocket.py
+++ b/resources/lib/websocket.py
@@ -367,7 +367,7 @@ class ABNF(object):
         _d = array.array("B", data.encode())
         for i, _v in enumerate(_d):
             _d[i] ^= _m[i % 4]
-        return ''.join(_d)
+        return ''.join(map(str, _d))
 
 
 class WebSocket(object):

--- a/resources/lib/websocket_client.py
+++ b/resources/lib/websocket_client.py
@@ -96,13 +96,13 @@ class WebSocket(backgroundthread.KillableThread):
                         timeout=1,
                         sslopt=sslopt,
                         enable_multithread=True)
-                except IOError:
+                except IOError as e:
                     # Server is probably offline
-                    LOG.debug("%s: IOError connecting", self.__class__.__name__)
+                    LOG.debug("%s: IOError connecting: %s", self.__class__.__name__, e)
                     self.ws = None
                     self._sleep_cycle()
-                except websocket.WebSocketTimeoutException:
-                    LOG.debug("%s: WebSocketTimeoutException", self.__class__.__name__)
+                except websocket.WebSocketTimeoutException as e:
+                    LOG.debug("%s: WebSocketTimeoutException: %s", self.__class__.__name__, e)
                     self.ws = None
                     self._sleep_cycle()
                 except websocket.WebsocketRedirect as e:

--- a/resources/lib/websocket_client.py
+++ b/resources/lib/websocket_client.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from logging import getLogger
 from json import loads
 from ssl import CERT_NONE

--- a/resources/lib/widgets.py
+++ b/resources/lib/widgets.py
@@ -7,6 +7,7 @@ Loads of different functions called in SEPARATE Python instances through
 e.g. plugin://... calls. Hence be careful to only rely on window variables.
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
 from logging import getLogger
 
 import xbmc
@@ -295,7 +296,7 @@ def prepare_listitem(item):
         if "imdbnumber" not in properties and "imdbnumber" in item:
             properties["imdbnumber"] = item["imdbnumber"]
         if "imdbnumber" not in properties and "uniqueid" in item:
-            for value in item["uniqueid"].values():
+            for value in list(item["uniqueid"].values()):
                 if value.startswith("tt"):
                     properties["imdbnumber"] = value
 
@@ -420,8 +421,8 @@ def prepare_listitem(item):
             item["thumbnail"] = art["thumb"]
 
         # clean art
-        for key, value in art.iteritems():
-            if not isinstance(value, (str, unicode)):
+        for key, value in art.items():
+            if not isinstance(value, str):
                 art[key] = ""
             elif value:
                 art[key] = get_clean_image(value)
@@ -472,7 +473,7 @@ def create_listitem(item, as_tuple=True, offscreen=True,
             nodetype = "Music"
 
         # extra properties
-        for key, value in item["extraproperties"].iteritems():
+        for key, value in item["extraproperties"].items():
             liz.setProperty(key, value)
 
         # video infolabels

--- a/resources/lib/windows/direct_path_sources.py
+++ b/resources/lib/windows/direct_path_sources.py
@@ -6,10 +6,12 @@
            e.g. smb paths
 """
 from __future__ import absolute_import, division, unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 from logging import getLogger
 import re
 import socket
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 import xbmc
 
@@ -156,7 +158,7 @@ def start():
                 xml.write_xml = False
                 return
             user = user.strip()
-            user = urllib.quote(user)
+            user = urllib.parse.quote(user)
             user = user.decode('utf-8')
             # "Password"
             # May also be blank!! (=user aborts dialog)
@@ -165,7 +167,7 @@ def start():
                                     '',
                                     type='{alphanum}',
                                     option='{hide}')
-            password = urllib.quote(password)
+            password = urllib.parse.quote(password)
             password = password.decode('utf-8')
             utils.etree.SubElement(entry,
                                    'from',

--- a/resources/lib/windows/kodigui.py
+++ b/resources/lib/windows/kodigui.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
+from builtins import zip
+from builtins import str
+from builtins import range
+from builtins import object
 import xbmc
 import xbmcgui
 import time
@@ -12,7 +16,7 @@ from .. import app
 MONITOR = None
 
 
-class BaseFunctions:
+class BaseFunctions(object):
     xmlFile = ''
     path = ''
     theme = ''
@@ -187,7 +191,7 @@ class BaseDialog(xbmcgui.WindowXMLDialog, BaseFunctions):
         pass
 
 
-class ControlledBase:
+class ControlledBase(object):
     def doModal(self):
         self.show()
         self.wait()
@@ -242,10 +246,10 @@ class ManagedListItem(object):
         self._manager = None
         self._valid = True
         if properties:
-            for k, v in properties.items():
+            for k, v in list(properties.items()):
                 self.setProperty(k, v)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self._valid
 
     @property
@@ -281,7 +285,7 @@ class ManagedListItem(object):
         self.listItem.setIconImage(self.iconImage)
         self.listItem.setThumbnailImage(self.thumbnailImage)
         self.listItem.setPath(self.path)
-        for k in self._manager._properties.keys():
+        for k in list(self._manager._properties.keys()):
             self.listItem.setProperty(k, self.properties.get(k) or '')
 
     def clear(self):
@@ -615,9 +619,9 @@ class ManagedControlList(object):
     def getViewRange(self):
         viewPosition = self.getViewPosition()
         selected = self.getSelectedPosition()
-        return range(max(selected - viewPosition, 0),
+        return list(range(max(selected - viewPosition, 0),
                      min(selected + (self._maxViewIndex - viewPosition) + 1,
-                         self.size() - 1))
+                         self.size() - 1)))
 
     def positionIsValid(self, pos):
         return 0 <= pos < self.size()
@@ -751,7 +755,7 @@ class MultiWindow(object):
         self._current.setProperty(key, value)
 
     def _onFirstInit(self):
-        for k, v in self._properties.items():
+        for k, v in list(self._properties.items()):
             self._current.setProperty(k, v)
         self.onFirstInit()
 
@@ -897,7 +901,7 @@ class SafeControlEdit(object):
         self._setText(self.getText()[:-1])
 
 
-class PropertyTimer():
+class PropertyTimer(object):
     def __init__(self, window_id, timeout, property_, value='', init_value='1', addon_id=None, callback=None):
         self._winID = window_id
         self._timeout = timeout
@@ -976,7 +980,7 @@ class PropertyTimer():
             self._start()
 
 
-class WindowProperty():
+class WindowProperty(object):
     def __init__(self, win, prop, val='1', end=None):
         self.win = win
         self.prop = prop
@@ -995,7 +999,7 @@ class WindowProperty():
         self.win.setProperty(self.prop, self.end or self.old)
 
 
-class GlobalProperty():
+class GlobalProperty(object):
     def __init__(self, prop, val='1', end=None):
         import xbmcaddon
         self._addonID = xbmcaddon.Addon().getAddonInfo('id')

--- a/resources/lib/windows/userselect.py
+++ b/resources/lib/windows/userselect.py
@@ -6,6 +6,7 @@
            (home) users
 """
 from __future__ import absolute_import, division, unicode_literals
+from builtins import str
 from logging import getLogger
 import xbmc
 import xbmcgui


### PR DESCRIPTION
OK, after doing more reading, I started over with using futurize instead of 2to3.  This should hopefully ensure backward compatibility.  This is still not functional (websocket.py is very unhappy), but should be a better start.  I am very limited on time for now, so I might not be able to get back to this in the near future.