### PR TITLE
Fix DirectPaths when a video's folder name is identical to a video's filename (you will need to manually reset the Kodi database)

### DIFF
--- a/resources/lib/itemtypes/movies.py
+++ b/resources/lib/itemtypes/movies.py
@@ -5,7 +5,7 @@ from logging import getLogger
 
 from .common import ItemBase
 from ..plex_api import API
-from .. import app, variables as v, plex_functions as PF
+from .. import app, variables as v, plex_functions as PF, utils
 
 LOG = getLogger('PLEX.movies')
 
@@ -54,7 +54,7 @@ class Movie(ItemBase):
                 else:
                     # Network share
                     filename = playurl.rsplit("/", 1)[1]
-                path = playurl.replace(filename, "")
+                path = utils.rreplace(playurl, filename, "", 1)
                 kodi_pathid = self.kodidb.add_path(path,
                                                    content='movies',
                                                    scraper='metadata.local')

--- a/resources/lib/itemtypes/music.py
+++ b/resources/lib/itemtypes/music.py
@@ -7,7 +7,7 @@ from .common import ItemBase
 from ..plex_api import API
 from ..plex_db import PlexDB, PLEXDB_LOCK
 from ..kodi_db import KodiMusicDB, KODIDB_LOCK
-from .. import plex_functions as PF, db, timing, app, variables as v
+from .. import plex_functions as PF, db, timing, app, variables as v, utils
 
 LOG = getLogger('PLEX.music')
 
@@ -539,7 +539,7 @@ class Song(MusicMixin, ItemBase):
                 else:
                     # Network share
                     filename = playurl.rsplit("/", 1)[1]
-                path = playurl.replace(filename, "")
+                path = utils.rreplace(playurl, filename, "", 1)
         if do_indirect:
             # Plex works a bit differently
             path = "%s%s" % (app.CONN.server, xml[0][0].get('key'))

--- a/resources/lib/itemtypes/tvshows.py
+++ b/resources/lib/itemtypes/tvshows.py
@@ -5,7 +5,7 @@ from logging import getLogger
 
 from .common import ItemBase, process_path
 from ..plex_api import API
-from .. import plex_functions as PF, app, variables as v
+from .. import plex_functions as PF, app, variables as v, utils
 
 LOG = getLogger('PLEX.tvshows')
 
@@ -434,7 +434,7 @@ class Episode(TvShowMixin, ItemBase):
                 else:
                     # Network share
                     filename = playurl.rsplit("/", 1)[1]
-                path = playurl.replace(filename, "")
+                path = utils.rreplace(playurl, filename, "", 1)
                 parent_path_id = self.kodidb.parent_path_id(path)
                 kodi_pathid = self.kodidb.add_path(path,
                                                    id_parent_path=parent_path_id)

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -249,6 +249,15 @@ def ERROR(txt='', hide_tb=False, notify=False, cancel_sync=False):
     return short
 
 
+def rreplace(s, old, new, occurrence=-1):
+    """
+    Replaces the string old [str, unicode] with new from the RIGHT given a
+    string s.
+    """
+    li = s.rsplit(old, occurrence)
+    return new.join(li)
+
+
 class AttributeDict(dict):
     """
     Turns an etree xml response's xml.attrib into an object with attributes


### PR DESCRIPTION
- Fixes #1104 