### PR TITLE
Added support for custom set of safe characters when escaping paths

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -881,6 +881,11 @@ msgid "Escape special characters in path (e.g. space to %20)"
 msgstr ""
 
 # PKC Settings - Customize Paths
+msgctxt "#39090"
+msgid "Safe characters for http(s), dav(s) and (s)ftp urls"
+msgstr ""
+
+# PKC Settings - Customize Paths
 msgctxt "#39037"
 msgid "Original Plex MOVIE path to replace:"
 msgstr ""

--- a/resources/language/resource.language.es_ES/strings.po
+++ b/resources/language/resource.language.es_ES/strings.po
@@ -965,7 +965,12 @@ msgstr ""
 # PKC Settings - Customize Paths
 msgctxt "#39036"
 msgid "Escape special characters in path (e.g. space to %20)"
-msgstr "Escapar caracteres especiales en la ruta (i.e. espacio a %20)"
+msgstr "Escapar caracteres especiales en la ruta (p. ej. espacio a %20)"
+
+# PKC Settings - Customize Paths
+msgctxt "#39090"
+msgid "Safe characters for http(s), dav(s) and (s)ftp urls"
+msgstr "Caracteres seguros para urls http(s), dav(s) y (s)ftp"
 
 # PKC Settings - Customize Paths
 msgctxt "#39037"

--- a/resources/lib/app/libsync.py
+++ b/resources/lib/app/libsync.py
@@ -42,6 +42,7 @@ class Sync(object):
         self.remapSMBphotoNew = None
         # Escape path?
         self.escape_path = None
+        self.escape_path_safe_chars = None
         # Shall we replace custom user ratings with the number of versions available?
         self.indicate_media_versions = None
         # Will sync movie trailer differently: either play trailer directly or show
@@ -109,6 +110,7 @@ class Sync(object):
         self.remapSMBphotoOrg = remove_trailing_slash(utils.settings('remapSMBphotoOrg'))
         self.remapSMBphotoNew = remove_trailing_slash(utils.settings('remapSMBphotoNew'))
         self.escape_path = utils.settings('escapePath') == 'true'
+        self.escape_path_safe_chars = utils.settings('escapePathSafeChars').encode('utf-8')
         self.indicate_media_versions = utils.settings('indicate_media_versions') == "true"
         self.sync_specific_plex_playlists = utils.settings('syncSpecificPlexPlaylists') == 'true'
         self.sync_specific_kodi_playlists = utils.settings('syncSpecificKodiPlaylists') == 'true'

--- a/resources/lib/plex_api/media.py
+++ b/resources/lib/plex_api/media.py
@@ -319,7 +319,7 @@ class Media(object):
             if path.startswith('\\\\'):
                 path = 'smb:' + path.replace('\\', '/')
         if app.SYNC.escape_path:
-            path = utils.escape_path(path)
+            path = utils.escape_path(path, app.SYNC.escape_path_safe_chars)
         if (app.SYNC.path_verified and not force_check) or omit_check:
             return path
 

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -398,8 +398,8 @@ def escape_path(path, safe_url_char=SAFE_URL_CHARACTERS):
     """
     is_http_dav_ftp = HTTP_DAV_FTP.match(path)
     if is_http_dav_ftp:
-        # If path seems to be a http(s), dav(s) or (s)ftp url, the escape path will be constructed using RegExp and
-        # using safe_url_char as safe characters not to be escaped
+        # If path seems to be a http(s), dav(s) or (s)ftp url, the escape path will be constructed
+        # using RegExp and using safe_url_char as safe characters not to be escaped
         protocol = is_http_dav_ftp.group(1)
         user = is_http_dav_ftp.group(6)
         psswd = is_http_dav_ftp.group(7)
@@ -420,7 +420,8 @@ def escape_path(path, safe_url_char=SAFE_URL_CHARACTERS):
                u'/' + \
                (url_path if url_path else u'')
     else:
-        # If paths does not seem to be a http(s), dav(s) or (s)ftp url (e.g. plugin://), escape path as before
+        # If paths does not seem to be a http(s), dav(s) or (s)ftp url (e.g. plugin://)
+        # escape path as before
         return urllib.quote(path.encode('utf-8'),
                             safe=SAFE_URL_CHARACTERS).decode('utf-8')
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -101,6 +101,7 @@
 		<setting id="remapSMBphotoOrg" type="text" label="39045" default="" visible="eq(-7,true)" subsetting="true" /> <!-- Original Plex MUSIC path to replace: -->
 		<setting id="remapSMBphotoNew" type="text" label="39046" default="smb://" visible="eq(-8,true)" subsetting="true" /> <!-- Replace Plex MUSIC with: -->
         <setting id="escapePath" type="bool" label="39036" default="false" /> <!-- Escape special characters in path (e.g. space to %20) -->
+        <setting id="escapePathSafeChars" type="text" label="39090" default="%/:=&amp;?~#+!$,;'@()*[]" visible="eq(-1,true)" subsetting="true"/> <!-- Safe characters for http(s), dav(s) and (s)ftp urls -->
 	</category>
 
 	<category label="30516"><!-- Playback -->


### PR DESCRIPTION
**Added support for custom set of safe characters (configured via addon settings) when escaping paths using direct paths for http(s), dav(s) and (s)ftp URLs.**

Currently the following characters are defined as safe (i.e. not being escaped) when escaping direct paths: `%/:=&?~#+!$,;'@()*[]`

When I was trying to get rclone to serve my google drive content in a webdav server, I realised that (at least) parenthesis and brackets should be escaped, thus the need for specifying a custom set of safe characters. I have successfully made this setup work with `/+` as custom set of safe characters.

I have added an option to the addon settings to specify the list of characters not to be escaped, which by default will be the same as the currently hard-coded set.

This custom set will only be used if the path is identified as http(s), dav(s) or (s)ftp using RegExp. In any other case, the hard-coded set of safe characters will be used.

I have tested this with dav urls but it should work fine for http and ftp url as well.