### PR TITLE
Change `thread.isAlive` to `thread.is_alive`

### DIFF
--- a/resources/lib/backgroundthread.py
+++ b/resources/lib/backgroundthread.py
@@ -377,7 +377,7 @@ class BackgroundWorker(object):
         return self._abort or app.APP.monitor.abortRequested()
 
     def start(self):
-        if self._thread and self._thread.isAlive():
+        if self._thread and self._thread.is_alive():
             return
 
         self._thread = KillableThread(target=self._queueLoop, name='BACKGROUND-WORKER({0})'.format(self.name))
@@ -403,13 +403,13 @@ class BackgroundWorker(object):
         if self._task:
             self._task.cancel()
 
-        if block and self._thread and self._thread.isAlive():
+        if block and self._thread and self._thread.is_alive():
             LOG.debug('thread (%s): Waiting...', self.name)
             self._thread.join()
             LOG.debug('thread (%s): Done', self.name)
 
     def working(self):
-        return self._thread and self._thread.isAlive()
+        return self._thread and self._thread.is_alive()
 
 
 class NonstoppingBackgroundWorker(BackgroundWorker):

--- a/resources/lib/plex_companion.py
+++ b/resources/lib/plex_companion.py
@@ -333,7 +333,7 @@ class PlexCompanion(backgroundthread.KillableThread):
             try:
                 message_count += 1
                 if httpd:
-                    if not thread.isAlive():
+                    if not thread.is_alive():
                         # Use threads cause the method will stall
                         thread = Thread(target=httpd.handle_request)
                         thread.start()

--- a/resources/lib/plex_functions.py
+++ b/resources/lib/plex_functions.py
@@ -377,7 +377,7 @@ def _pms_list_from_plex_tv(token):
     while True:
         # Remove finished threads
         for thread in threads:
-            if not thread.isAlive():
+            if not thread.is_alive():
                 threads.remove(thread)
         if len(threads) < max_threads:
             try:

--- a/resources/lib/windows/kodigui.py
+++ b/resources/lib/windows/kodigui.py
@@ -928,7 +928,7 @@ class PropertyTimer(object):
         self._onTimeout()
 
     def _stopped(self):
-        return not self._thread or not self._thread.isAlive()
+        return not self._thread or not self._thread.is_alive()
 
     def _reset(self):
         self._endTime = time.time() + self._timeout


### PR DESCRIPTION
Python 3.9 has removed the method `thread.isAlive` and `thread.is_alive` should be used. This should be compatble with previous versions, as `thread.is_alive` exists also on Python 2. 