### PR TITLE
Fix OSError: Invalid argument when Plex returns an invalid timestamp

### DIFF
--- a/resources/lib/timing.py
+++ b/resources/lib/timing.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from logging import getLogger
 from datetime import datetime, timedelta
 from time import localtime, strftime
+
+LOG = getLogger('PLEX.timing')
 
 EPOCH = datetime.utcfromtimestamp(0)
 
@@ -28,7 +31,13 @@ def unix_date_to_kodi(unix_kodi_time):
 
     Output: Y-m-d h:m:s = 2009-04-05 23:16:04
     """
-    return strftime('%Y-%m-%d %H:%M:%S', localtime(float(unix_kodi_time)))
+    try:
+        return strftime('%Y-%m-%d %H:%M:%S', localtime(float(unix_kodi_time)))
+    except Exception:
+        LOG.exception('Received an illegal timestamp from Plex: %s. '
+                      'Using 1970-01-01 12:00:00',
+                      unix_kodi_time)
+        return '1970-01-01 12:00:00'
 
 
 def plex_date_to_kodi(plex_timestamp):


### PR DESCRIPTION
- Discovered when connecting to the users library in #1295 