### PR TITLE
ValueError: invalid literal for int() for invalid dates sent by Plex

### DIFF
--- a/resources/lib/library_sync/fill_metadata_queue.py
+++ b/resources/lib/library_sync/fill_metadata_queue.py
@@ -41,8 +41,8 @@ class FillMetadataQueue(common.LibrarySyncMixin,
                 plex_id = int(xml.get('ratingKey'))
                 checksum = int('{}{}'.format(
                     plex_id,
-                    xml.get('updatedAt',
-                            xml.get('addedAt', '1541572987')).replace('-', '')))
+                    abs(int(xml.get('updatedAt',
+                            xml.get('addedAt', '1541572987'))))))
                 if (not self.repair and
                         plexdb.checksum(plex_id, section.plex_type) == checksum):
                     continue

--- a/resources/lib/plex_api/base.py
+++ b/resources/lib/plex_api/base.py
@@ -231,8 +231,8 @@ class Base(object):
         addedAt is used.
         """
         return int('%s%s' % (self.xml.get('ratingKey'),
-                             self.xml.get('updatedAt') or
-                             self.xml.get('addedAt', '1541572987')))
+                             abs(int(self.xml.get('updatedAt') or
+                                     self.xml.get('addedAt', '1541572987')))))
 
     def title(self):
         """


### PR DESCRIPTION
- Fixes #1307