### PR TITLE
Get rid of Python arrow; hopefully fix many Python import errors (also occuring in other add-ons!)

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -7,7 +7,6 @@
     <import addon="plugin.video.plexkodiconnect.movies" version="3.0.0" />
     <import addon="plugin.video.plexkodiconnect.tvshows" version="3.0.0" />
     <import addon="metadata.themoviedb.org.python" version="1.3.1+matrix.1" />
-    <import addon="script.module.arrow" version="0.15.5"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video audio image</provides>

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from unicodedata import normalize
 from threading import Lock
 import urllib
-import arrow
 # Originally tried faster cElementTree, but does NOT work reliably with Kodi
 # etree parse unsafe; make sure we're always receiving unicode
 from . import defused_etree as etree
@@ -632,19 +631,22 @@ def indent(elem, level=0):
         LOG.info('Indentation failed with: %s', err)
 
 
-def localdate_from_utc_string(timestring):
-    """helper to convert internal utc time (used in pvr) to local timezone"""
-    utc_datetime = arrow.get(timestring)
-    local_datetime = utc_datetime.to('local')
-    return local_datetime.format("YYYY-MM-DD HH:mm:ss")
+# Python's arrow library is broken for Kodi
+# Importing from several Python instances is faulty :-(
+
+# def localdate_from_utc_string(timestring):
+#     """helper to convert internal utc time (used in pvr) to local timezone"""
+#     utc_datetime = arrow.get(timestring)
+#     local_datetime = utc_datetime.to('local')
+#     return local_datetime.format("YYYY-MM-DD HH:mm:ss")
 
 
-def localized_date_time(timestring):
-    """returns localized version of the timestring (used in pvr)"""
-    date_time = arrow.get(timestring)
-    local_date = date_time.strftime(xbmc.getRegion("dateshort"))
-    local_time = date_time.strftime(xbmc.getRegion("time").replace(":%S", ""))
-    return local_date, local_time
+# def localized_date_time(timestring):
+#     """returns localized version of the timestring (used in pvr)"""
+#     date_time = arrow.get(timestring)
+#     local_date = date_time.strftime(xbmc.getRegion("dateshort"))
+#     local_time = date_time.strftime(xbmc.getRegion("time").replace(":%S", ""))
+#     return local_date, local_time
 
 
 class XmlKodiSetting(object):

--- a/resources/lib/widgets.py
+++ b/resources/lib/widgets.py
@@ -7,7 +7,6 @@ Loads of different functions called in SEPARATE Python instances through
 e.g. plugin://... calls. Hence be careful to only rely on window variables.
 """
 from logging import getLogger
-import arrow
 
 import xbmc
 import xbmcgui
@@ -387,22 +386,22 @@ def prepare_listitem(item):
             properties["Album_Description"] = item.get('album_description')
 
         # pvr properties
-        if "starttime" in item:
-            # convert utc time to local time
-            item["starttime"] = utils.localdate_from_utc_string(item["starttime"])
-            item["endtime"] = utils.localdate_from_utc_string(item["endtime"])
-            # set localized versions of the time and date as additional props
-            startdate, starttime = utils.localized_date_time(item['starttime'])
-            enddate, endtime = utils.localized_date_time(item['endtime'])
-            properties["StartTime"] = starttime
-            properties["StartDate"] = startdate
-            properties["EndTime"] = endtime
-            properties["EndDate"] = enddate
-            properties["Date"] = "%s %s-%s" % (startdate, starttime, endtime)
-            properties["StartDateTime"] = "%s %s" % (startdate, starttime)
-            properties["EndDateTime"] = "%s %s" % (enddate, endtime)
-            # set date to startdate
-            item["date"] = arrow.get(item["starttime"]).format("DD.MM.YYYY")
+        # if "starttime" in item:
+        #     # convert utc time to local time
+        #     item["starttime"] = utils.localdate_from_utc_string(item["starttime"])
+        #     item["endtime"] = utils.localdate_from_utc_string(item["endtime"])
+        #     # set localized versions of the time and date as additional props
+        #     startdate, starttime = utils.localized_date_time(item['starttime'])
+        #     enddate, endtime = utils.localized_date_time(item['endtime'])
+        #     properties["StartTime"] = starttime
+        #     properties["StartDate"] = startdate
+        #     properties["EndTime"] = endtime
+        #     properties["EndDate"] = enddate
+        #     properties["Date"] = "%s %s-%s" % (startdate, starttime, endtime)
+        #     properties["StartDateTime"] = "%s %s" % (startdate, starttime)
+        #     properties["EndDateTime"] = "%s %s" % (enddate, endtime)
+        #     # set date to startdate
+        #     item["date"] = arrow.get(item["starttime"]).format("DD.MM.YYYY")
         if "channellogo" in item:
             properties["channellogo"] = item["channellogo"]
             properties["channelicon"] = item["channellogo"]


### PR DESCRIPTION
- Hopefully fixes #1488
- Hopefully fixes `script.skin.helper` and `script.skin.helper.backgrounds` exceptions like
```
2021-05-24 11:39:25.561 T:31113 WARNING <general>: Skin Helper Backgrounds --> Exception details: Type: ModuleNotFoundError Value: No module named 'Image' Traceback: Traceback (most recent call last):
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.skin.helper.backgrounds/resources/lib/wallimages.py", line 24, in <module>
                                                       from PIL import Image
                                                   ModuleNotFoundError: No module named 'PIL'
                                                   
                                                   During handling of the above exception, another exception occurred:
                                                   
                                                   Traceback (most recent call last):
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.skin.helper.backgrounds/resources/lib/wallimages.py", line 32, in <module>
                                                       import Image
                                                   ModuleNotFoundError: No module named 'Image'
```