### PR TITLE
Websocket Fix AttributeError: 'NoneType' object has no attribute 'is_ssl'

### DIFF
--- a/resources/lib/websocket/_core.py
+++ b/resources/lib/websocket/_core.py
@@ -197,7 +197,10 @@ class WebSocket(object):
             return None
 
     def is_ssl(self):
-        return isinstance(self.sock, ssl.SSLSocket)
+        try:
+            return isinstance(self.sock, ssl.SSLSocket)
+        except:
+            return False
 
     headers = property(getheaders)
 


### PR DESCRIPTION
- As detailed here (unfortunately fix is unavailable for Python 2): https://github.com/websocket-client/websocket-client/issues/720