### PR TITLE
Add playback settings to let the user choose whether Plex or Kodi provides the default audio or subtitle stream on playback start [backport]

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -665,6 +665,16 @@ msgctxt "#30546"
 msgid "Pick the first video if several versions are present"
 msgstr ""
 
+# PKC Settings - Playback
+msgctxt "#30547"
+msgid "Who picks the audio stream on playback start?"
+msgstr ""
+
+# PKC Settings - Playback
+msgctxt "#30548"
+msgid "Who picks subtitles on playback start?"
+msgstr ""
+
 # Welcome to Plex notification
 msgctxt "#33000"
 msgid "Welcome"

--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -29,6 +29,7 @@ class KodiMonitor(xbmc.Monitor):
     """
     PKC implementation of the Kodi Monitor class. Invoke only once.
     """
+
     def __init__(self):
         self._already_slept = False
         self._switched_to_plex_streams = True
@@ -390,7 +391,10 @@ class KodiMonitor(xbmc.Monitor):
         if not self._switched_to_plex_streams:
             # We need to switch to the Plex streams ONCE upon playback start
             # after onavchange has been fired
-            item.switch_to_plex_streams()
+            if utils.settings('audioStreamPick') == '0':
+                item.switch_to_plex_stream('audio')
+            if utils.settings('subtitleStreamPick') == '0':
+                item.switch_to_plex_stream('subtitle')
             self._switched_to_plex_streams = True
         else:
             item.on_av_change(playerid)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -114,6 +114,8 @@
         <setting id="trailerNumber" type="slider" label="39000" default="3" visible="eq(-2,true)" range="1,1,15" option="int" />
         <setting id="enableSkipIntro" type="bool" label="30525" default="true" /><!-- Enable skipping of intros -->
         <setting id="firstVideoStream" type="bool" label="30546" default="false" /><!-- Pick the first video if several versions are present -->
+        <setting id="audioStreamPick" type="enum" label="30547" values="Plex|Kodi" default="0" /><!-- Who picks the audio stream on playback start? -->
+        <setting id="subtitleStreamPick" type="enum" label="30548" values="Plex|Kodi" default="0" /><!-- Who picks subtitles on playback start? -->
 	    <setting id="ignoreSpecialsNextEpisodes" type="bool" label="30527" default="false" />
         <setting id="resumeJumpBack" type="slider" label="30521" default="10" range="0,1,120" option="int" visible="false"/>
         <setting type="sep" />


### PR DESCRIPTION
- Backport of #1652 