### PR TITLE
Fix playback startup and AttributeError: 'bool' object has no attribute 'get'

### DIFF
--- a/resources/lib/plex_companion/common.py
+++ b/resources/lib/plex_companion/common.py
@@ -25,7 +25,7 @@ def proxy_headers():
 def proxy_params():
     params = {
         'deviceClass': 'pc',
-        'protocolCapabilities': 'timeline,playback,navigation,mirror,playqueues',
+        'protocolCapabilities': 'timeline,playback,navigation,playqueues',
         'protocolVersion': 3
     }
     if app.ACCOUNT.pms_token:

--- a/resources/lib/variables.py
+++ b/resources/lib/variables.py
@@ -445,9 +445,9 @@ CONTENT_FROM_PLEX_TYPE = {
 # Plex profile for transcoding and direct streaming
 # Uses the empty Generic.xml at Plex Media Server/Resources/Profiles for any
 # Playback decisions
-PLATFORM = 'Kodi'
+PLATFORM = 'Generic'
 # Version seems to be irrelevant for the generic platform
-PLATFORM_VERSION = KODILONGVERSION
+PLATFORM_VERSION = '1.0.0'
 # Overrides (replace=true) any existing entries in generic.xml
 STREAMING_HEADERS = {
     'X-Plex-Client-Profile-Extra':


### PR DESCRIPTION
- Fixes #1696
- Regression introduced in #1694 
- This reverts commit f2e2be6da7a21d7e89c0bad1d9922c1e2f4e2aaa.