### PR TITLE
Fix media not showing up in the library if Kodi masterlock has been activated. Kodi bugfix is also necessary, hopefully coming with Kodi 19.4, otherwise switch to Kodi 19.1

### DIFF
--- a/resources/lib/initialsetup.py
+++ b/resources/lib/initialsetup.py
@@ -526,7 +526,7 @@ class InitialSetup(object):
                                       force_create=True,
                                       top_element='sources') as xml:
                 changed = False
-                for extension in ('smb://', 'nfs://'):
+                for extension in ('smb://', 'nfs://', 'plugin://'):
                     root = xml.set_setting(['video'])
                     changed = self._add_sources(root, extension) or changed
                 if changed:


### PR DESCRIPTION
- Partially fixes #1718
- This PR needs to be merged into Kodi 19.x (NOT 20!) also: https://github.com/xbmc/xbmc/pull/20692