### PR TITLE
Fix FileExistsError when user deleted video library nodes

### DIFF
--- a/resources/lib/library_sync/sections.py
+++ b/resources/lib/library_sync/sections.py
@@ -20,10 +20,13 @@ SHOULD_CANCEL = None
 LIBRARY_PATH = path_ops.translate_path('special://profile/library/video/')
 # The video library might not yet exist for this user - create it
 if not path_ops.exists(LIBRARY_PATH):
-    path_ops.copytree(
-        src=path_ops.translate_path('special://xbmc/system/library/video'),
-        dst=LIBRARY_PATH,
-        copy_function=path_ops.shutil.copyfile)
+    try:
+        path_ops.copytree(
+            src=path_ops.translate_path('special://xbmc/system/library/video'),
+            dst=LIBRARY_PATH,
+            copy_function=path_ops.shutil.copyfile)
+    except FileExistsError:
+        LOG.warn('special://profile/library/video/ existed already')
 PLAYLISTS_PATH = path_ops.translate_path("special://profile/playlists/video/")
 if not path_ops.exists(PLAYLISTS_PATH):
     path_ops.makedirs(PLAYLISTS_PATH)


### PR DESCRIPTION
Fixes this error:
```
2022-12-29 09:19:56.362 T:6660    ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'FileExistsError'>
                                                   Error Contents: [WinError 183] Eine Datei kann nicht erstellt werden, wenn sie bereits vorhanden ist: 'C:\\Users\\kat\\AppData\\Roaming\\Kodi\\userdata\\library\\video\\'
                                                   Traceback (most recent call last):
                                                     File "C:\Users\kat\AppData\Roaming\Kodi\addons\plugin.video.plexkodiconnect\service.py", line 4, in <module>
                                                       from resources.lib import service_entry
                                                     File "C:\Users\kat\AppData\Roaming\Kodi\addons\plugin.video.plexkodiconnect\resources\lib\service_entry.py", line 12, in <module>
                                                       from . import sync, library_sync
                                                     File "C:\Users\kat\AppData\Roaming\Kodi\addons\plugin.video.plexkodiconnect\resources\lib\sync.py", line 7, in <module>
                                                       from . import library_sync, timing
                                                     File "C:\Users\kat\AppData\Roaming\Kodi\addons\plugin.video.plexkodiconnect\resources\lib\library_sync\__init__.py", line 2, in <module>
                                                       from .full_sync import start
                                                     File "C:\Users\kat\AppData\Roaming\Kodi\addons\plugin.video.plexkodiconnect\resources\lib\library_sync\full_sync.py", line 9, in <module>
                                                       from .fill_metadata_queue import FillMetadataQueue
                                                     File "C:\Users\kat\AppData\Roaming\Kodi\addons\plugin.video.plexkodiconnect\resources\lib\library_sync\fill_metadata_queue.py", line 5, in <module>
                                                       from . import common, sections
                                                     File "C:\Users\kat\AppData\Roaming\Kodi\addons\plugin.video.plexkodiconnect\resources\lib\library_sync\sections.py", line 23, in <module>
                                                       path_ops.copytree(
                                                     File "C:\Users\kat\AppData\Roaming\Kodi\addons\plugin.video.plexkodiconnect\resources\lib\path_ops.py", line 206, in copytree
                                                       return shutil.copytree(src, dst, *args, **kwargs)
                                                     File "C:\Program Files\Kodi\system\python\Lib\shutil.py", line 557, in copytree
                                                       return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
                                                     File "C:\Program Files\Kodi\system\python\Lib\shutil.py", line 458, in _copytree
                                                       os.makedirs(dst, exist_ok=dirs_exist_ok)
                                                     File "C:\Program Files\Kodi\system\python\Lib\os.py", line 223, in makedirs
                                                       mkdir(name, mode)
                                                   FileExistsError: [WinError 183] Eine Datei kann nicht erstellt werden, wenn sie bereits vorhanden ist: 'C:\\Users\\kat\\AppData\\Roaming\\Kodi\\userdata\\library\\video\\'
                                                   -->End of Python script error report<--
                                                   
```