### PR TITLE
Fix rating matching

### DIFF
--- a/resources/lib/plex_api/base.py
+++ b/resources/lib/plex_api/base.py
@@ -356,24 +356,24 @@ class Base(object):
 
     def ratingtype(self):
         """
-        Returns the kodi rating type after parsing the rating image link from
-        plex
+        Returns the ratingtype [str] first from 'audienceRatingImage'
+        (audience) if that fails, from ratingImage (critic). Returns 'default'
+        if both are not found
         """
-        rtype = self.xml.get('audienceRatingImage', '')
-        if 'rotten' in rtype:
+        rtype = 'default'
+        # audience ratings
+        rtypea = self.xml.get('audienceRatingImage', '')
+        if 'rotten' in rtypea:
             rtype = 'tomatometerallaudience'
-        elif 'imdb' in rtype:
+        elif 'imdb' in rtypea:
             rtype = 'imdb'
-        elif 'tmdb' in rtype:
+        elif 'themoviedb' in rtypea:
             rtype = 'themoviedb'
-        elif 'tvdb' in rtype:
+        elif 'tvdb' in rtypea:
             rtype = 'tvdb'
-        elif 'trakt' in rtype:
-            rtype = 'trakt'
-        elif 'metacritic' in rtype:
-            rtype = 'metacritic'
-        else:
-            rtype = 'default'
+        elif 'rotten' in self.xml.get('ratingImage', ''):
+            # critic ratings - fallback if no audience ratings
+            rtype = 'tomatometerallcritics'
         return rtype
 
     def votecount(self):


### PR DESCRIPTION
- Rating Type was looking for tmdb in plex audienceRatingImage when it should have been matching themoviedb.
- Original pull request: https://github.com/croneter/PlexKodiConnect/pull/1927
- Fixes https://github.com/croneter/PlexKodiConnect/issues/1911