### PR TITLE
Fix PKC not working properly if several Kodi video database versions are available, e.g. after an update of Kodi. Also fix sqlite3.OperationalError: table streamdetails has no column named strhdrtype (thanks @Son-Typ)

### DIFF
--- a/resources/lib/variables.py
+++ b/resources/lib/variables.py
@@ -723,7 +723,5 @@ def database_paths():
                 setattr(thismodule, actual_path, path)
                 break
 
-    if (DB_VIDEO_VERSION is None or
-            DB_MUSIC_VERSION is None or
-            DB_TEXTURE_VERSION is None):
+    if None in (DB_VIDEO_VERSION, DB_MUSIC_VERSION, DB_TEXTURE_VERSION):
         raise RuntimeError('Kodi database versions not supported by PKC')

--- a/resources/lib/variables.py
+++ b/resources/lib/variables.py
@@ -105,7 +105,7 @@ PKC_MACHINE_IDENTIFIER = None
 # Minimal PKC version needed for the Kodi database - otherwise need to recreate
 MIN_DB_VERSION = '3.2.1'
 
-# Supported databases - version numbers in tuples should decrease
+# Supported databases
 # See https://github.com/xbmc/xbmc/blob/master/xbmc/video/VideoDatabase.cpp
 SUPPORTED_VIDEO_DB = {
     19: (119, ),
@@ -715,7 +715,7 @@ def database_paths():
              ('Textures%s.db', SUPPORTED_TEXTURE_DB,
               'DB_TEXTURE_VERSION', 'DB_TEXTURE_PATH'))
     for string, versions, actual_version, actual_path in types:
-        for version in versions[KODIVERSION]:
+        for version in sorted(versions[KODIVERSION], reverse=True):
             file = string % version
             path = path_ops.path.join(database_path, file)
             if path_ops.exists(path):


### PR DESCRIPTION
- Fixes #1964 
- Fixes #1963
- Thanks @Son-Typ !