### PR TITLE
Fix movie issues in kodi 21

### DIFF
--- a/resources/lib/kodi_db/common.py
+++ b/resources/lib/kodi_db/common.py
@@ -6,7 +6,7 @@ from .. import db, path_ops
 
 KODIDB_LOCK = Lock()
 # Names of tables we generally leave untouched and e.g. don't wipe
-UNTOUCHED_TABLES = ('version', 'versiontagscan')
+UNTOUCHED_TABLES = ('version', 'versiontagscan', 'videoversiontype')
 
 
 class KodiDBBase(object):

--- a/resources/lib/kodi_db/video.py
+++ b/resources/lib/kodi_db/video.py
@@ -1063,7 +1063,7 @@ class KodiVideoDB(common.KodiDBBase):
         if self.has_video_version_table():
             self.cursor.execute(
                 '''
-                INSERT INTO videoversion(
+                INSERT OR REPLACE INTO videoversion(
                     idFile,
                     idMedia,
                     media_type,

--- a/resources/lib/kodi_db/video.py
+++ b/resources/lib/kodi_db/video.py
@@ -1060,22 +1060,25 @@ class KodiVideoDB(common.KodiDBBase):
                  ?, ?, ?, ?)
         ''', (args))
 
-        self.cursor.execute(
-            '''
-            INSERT INTO videoversion(
-                idFile,
-                idMedia,
-                media_type,
-                itemType,
-                idType)
-            VALUES
-                (?, ?, ?, ?, ?)
-        ''', (args[1], args[0], "movie", "0", 40400))
+        if self.has_video_version_table():
+            self.cursor.execute(
+                '''
+                INSERT INTO videoversion(
+                    idFile,
+                    idMedia,
+                    media_type,
+                    itemType,
+                    idType)
+                VALUES
+                    (?, ?, ?, ?, ?)
+            ''', (args[1], args[0], "movie", "0", 40400))
 
     @db.catch_operationalerrors
     def remove_movie(self, kodi_id):
         self.cursor.execute('DELETE FROM movie WHERE idMovie = ?', (kodi_id,))
-        self.cursor.execute('DELETE FROM videoversion WHERE idMedia = ?', (kodi_id,))
+
+        if self.has_video_version_table():
+            self.cursor.execute('DELETE FROM videoversion WHERE idMedia = ?', (kodi_id,))
 
     @db.catch_operationalerrors
     def update_userrating(self, kodi_id, kodi_type, userrating):
@@ -1096,3 +1099,8 @@ class KodiVideoDB(common.KodiDBBase):
             identifier = 'idShow'
         self.cursor.execute('''UPDATE %s SET userrating = ? WHERE ? = ?''' % table,
                             (userrating, identifier, kodi_id))
+    
+    @db.catch_operationalerrors
+    def has_video_version_table(self):
+        self.cursor.execute('SELECT COUNT(name) FROM sqlite_master WHERE type=\'table\' AND name=\'videoversion\'')
+        return self.cursor.fetchone()[0] == 1

--- a/resources/lib/kodi_db/video.py
+++ b/resources/lib/kodi_db/video.py
@@ -1060,9 +1060,22 @@ class KodiVideoDB(common.KodiDBBase):
                  ?, ?, ?, ?)
         ''', (args))
 
+        self.cursor.execute(
+            '''
+            INSERT INTO videoversion(
+                idFile,
+                idMedia,
+                media_type,
+                itemType,
+                idType)
+            VALUES
+                (?, ?, ?, ?, ?)
+        ''', (args[1], args[0], "movie", "0", 40400))
+
     @db.catch_operationalerrors
     def remove_movie(self, kodi_id):
         self.cursor.execute('DELETE FROM movie WHERE idMovie = ?', (kodi_id,))
+        self.cursor.execute('DELETE FROM videoversion WHERE idMedia = ?', (kodi_id,))
 
     @db.catch_operationalerrors
     def update_userrating(self, kodi_id, kodi_type, userrating):

--- a/resources/lib/kodi_db/video.py
+++ b/resources/lib/kodi_db/video.py
@@ -1099,7 +1099,7 @@ class KodiVideoDB(common.KodiDBBase):
             identifier = 'idShow'
         self.cursor.execute('''UPDATE %s SET userrating = ? WHERE ? = ?''' % table,
                             (userrating, identifier, kodi_id))
-    
+
     @db.catch_operationalerrors
     def has_video_version_table(self):
         self.cursor.execute('SELECT COUNT(name) FROM sqlite_master WHERE type=\'table\' AND name=\'videoversion\'')


### PR DESCRIPTION
Kodi 21 changed the `movie_view` db query, which broke support for movies added by PKC. We now need to insert a row into the `videoversion` table for each movie. Check [this issue](https://github.com/jellyfin/jellyfin-kodi/issues/808) for more information.  @AmonFlorian created a fix for jellyfin-kodi, which I applied to PKC.

Changes
- Update the `videoversion` table (when it exists) when adding/removing movies
- Don't touch the `videoversiontype` table when resetting the database. This table is created & [prepopulated](https://github.com/xbmc/xbmc/blob/213cb317db5687479e5cf1b4b5058082a6ddadb1/xbmc/video/VideoDatabase.cpp#L11935) by kodi.

Testing instructions:
1. Stop kodi
1. !! If you were ever on an alpha or beta version of kodi 21, I recommend deleting all your `MyVideos*.db` files to ensure you start from a good state. !!
   - This will ensure kodi creates a valid `videoversiontype` table
1. Apply PR changes to the python files in the addon folder
1. Start kodi
1. Reset the kodi databases from plexkodiconnect settings
1. Movies should now show up

Fixes #2025