### PR TITLE
Prevent excessive library refreshes when browsing libraries in Plex Web (thanks @Spacetech)

### DIFF
--- a/resources/lib/library_sync/websocket.py
+++ b/resources/lib/library_sync/websocket.py
@@ -205,6 +205,9 @@ def store_activity_message(data):
         elif message['Activity']['type'] != 'library.refresh.items':
             # Not the type of message relevant for us
             continue
+        elif message['Activity']['Context']['refreshed'] != True:
+            # The item was scanned but not actually refreshed
+            continue
         plex_id = PF.GetPlexKeyNumber(message['Activity']['Context']['key'])[1]
         if not plex_id:
             # Likely a Plex id like /library/metadata/3/children


### PR DESCRIPTION
Fixes #1997 

Whenever users click through shows, episodes, movies, etc in Plex Web, Plex sends activity events to a WebSocket. Plex does this because it's attempting to refresh some data for the item when a user views them. Here is an example of the websocket event that fires after clicking a movie:

![308389875-e7597b06-4283-4680-8cb8-ce18508f89ce](https://github.com/croneter/PlexKodiConnect/assets/824323/0d438ca3-5f26-4af1-a9d1-5c510ae32d45)

Assuming you have PKC background sync enabled, PKC is triggering Kodi library updates when this happens. The logic for processing the websocket message is [here](https://github.com/croneter/PlexKodiConnect/blob/cd3bf2ce0d7524c3d359f8e7254e8bcd9266ce84/resources/lib/library_sync/websocket.py#L192)

It's not ideal that browsing the library is constantly triggering churn in the database (PKC resyncs the item when this happens) & Kodi library updates. 

The websocket message looks like it indicates whether or not it actually refreshed the item (the `refreshed`) property. I propose that we leverage that and ignore the activity message when it's `false`.

For me, this issue is causing periodic screen flashing/flickering due to the Kodi skin I'm using, so it's quite annoying.