### PR TITLE
Separate intro / credit / commercial skip settings (thanks @Spacetech)

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1516,3 +1516,13 @@ msgstr ""
 msgctxt "#39720"
 msgid "Auto skip intro"
 msgstr ""
+
+# PKC Settings - Playback
+msgctxt "#39721"
+msgid "Auto skip credits"
+msgstr ""
+
+# PKC Settings - Playback
+msgctxt "#39722"
+msgid "Auto skip commercials"
+msgstr ""

--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -331,11 +331,14 @@ class KodiMonitor(xbmc.Monitor):
                 container_key = '/playQueues/%s' % playqueue.id
             else:
                 container_key = '/library/metadata/%s' % plex_id
-        # Mechanik for Plex skip intro feature
-        if utils.settings('enableSkipIntro') == 'true':
+        # Mechanik for Plex skip intro/credits/commercials feature
+        if utils.settings('enableSkipIntro') == 'true' \
+                or utils.settings('enableSkipCredits') == 'true' \
+                or utils.settings('enableSkipCommercials') == 'true':
             status['markers'] = item.api.markers()
-            status['first_credits_marker'] = item.api.first_credits_marker()
-            status['final_credits_marker'] = item.api.final_credits_marker()
+            if utils.settings('enableSkipCredits') == 'true':
+                status['first_credits_marker'] = item.api.first_credits_marker()
+                status['final_credits_marker'] = item.api.final_credits_marker()
         if item.playmethod is None and path and not path.startswith('plugin://'):
             item.playmethod = v.PLAYBACK_METHOD_DIRECT_PATH
         item.playerid = playerid

--- a/resources/lib/skip_plex_markers.py
+++ b/resources/lib/skip_plex_markers.py
@@ -7,11 +7,10 @@ from . import app, utils, variables as v
 # Supported types of markers that can be skipped; values here will be
 # displayed to the user when skipping is available
 MARKERS = {
-    'intro': utils.lang(30525),  # Skip intro
-    'credits': utils.lang(30526),  # Skip credits
-    'commercial': utils.lang(30530)  # Skip commercial
+    'intro': (utils.lang(30525), 'enableSkipIntro', 'enableAutoSkipIntro'), # Skip intro
+    'credits': (utils.lang(30526), 'enableSkipCredits', 'enableAutoSkipCredits'),  # Skip credits
+    'commercial': (utils.lang(30530), 'enableSkipCommercials', 'enableAutoSkipCommercials'),  # Skip commercial
 }
-
 
 def skip_markers(markers):
     try:
@@ -20,8 +19,10 @@ def skip_markers(markers):
         # XBMC is not playing any media file yet
         return
     within_marker = False
+    marker_definition = None
     for start, end, typus, _ in markers:
-        if start <= progress < end:
+        marker_definition = MARKERS[typus]
+        if utils.settings(marker_definition[1]) == "true" and start <= progress < end:
             within_marker = True
             break
     if within_marker and app.APP.skip_markers_dialog is None:
@@ -32,9 +33,9 @@ def skip_markers(markers):
             v.ADDON_PATH,
             'default',
             '1080i',
-            marker_message=MARKERS[typus],
+            marker_message=marker_definition[0],
             marker_end=end)
-        if utils.settings('enableAutoSkipIntro') == "true":
+        if utils.settings(marker_definition[2]) == "true":
             app.APP.skip_markers_dialog.seekTimeToEnd()
         else:
             app.APP.skip_markers_dialog.show()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -115,6 +115,10 @@
         <setting id="trailerNumber" type="slider" label="39000" default="3" visible="eq(-2,true)" range="1,1,15" option="int" />
         <setting id="enableSkipIntro" type="bool" label="30525" default="true" /><!-- Enable skipping of intros -->
         <setting id="enableAutoSkipIntro" type="bool" label="39720" default="false" visible="eq(-1,true)" subsetting="true" /><!-- Enable auto skipping of intros -->
+        <setting id="enableSkipCredits" type="bool" label="30526" default="true" /><!-- Enable skipping of credits -->
+        <setting id="enableAutoSkipCredits" type="bool" label="39721" default="false" visible="eq(-1,true)" subsetting="true" /><!-- Enable auto skipping of credits -->
+        <setting id="enableSkipCommercials" type="bool" label="30530" default="true" /><!-- Enable skipping of commercials -->
+        <setting id="enableAutoSkipCommercials" type="bool" label="39722" default="false" visible="eq(-1,true)" subsetting="true" /><!-- Enable auto skipping of commercials -->
         <setting id="firstVideoStream" type="bool" label="30546" default="false" /><!-- Pick the first video if several versions are present -->
         <setting id="audioStreamPick" type="enum" label="30547" values="Plex|Kodi" default="0" /><!-- Who picks the audio stream on playback start? -->
         <setting id="subtitleStreamPick" type="enum" label="30548" values="Plex|Kodi" default="0" /><!-- Who picks subtitles on playback start? -->


### PR DESCRIPTION
Implements the ask at #1985. Separate the skip and auto skip settings between intro & credit & commercials.

It'll look like this:
![20240228_193754-1](https://github.com/croneter/PlexKodiConnect/assets/824323/52d95f99-67a6-4533-8fc7-e07c6655318e)
