### PR TITLE
New setting: Allow delaying background sync while playing videos

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -878,6 +878,11 @@ msgctxt "#39026"
 msgid "Enable constant background sync"
 msgstr ""
 
+# PKC Settings - Sync
+msgctxt "#39027"
+msgid "Delay background sync while media is playing"
+msgstr ""
+
 # Pop-up on initial sync
 msgctxt "#39028"
 msgid "CAUTION! If you choose \"Native\" mode , you might loose access to certain Plex features such as: Plex trailers and transcoding options. ALL Plex shares need to use direct paths (e.g. smb://myNAS/mymovie.mkv or \\\\myNAS/mymovie.mkv)!"

--- a/resources/lib/library_sync/websocket.py
+++ b/resources/lib/library_sync/websocket.py
@@ -205,7 +205,8 @@ def store_activity_message(data):
         elif message['Activity']['type'] != 'library.refresh.items':
             # Not the type of message relevant for us
             continue
-        elif message['Activity']['Context']['refreshed'] != True:
+        elif message['Activity']['Context'].get('refreshed') is not None and \
+                message['Activity']['Context']['refreshed'] == False:
             # The item was scanned but not actually refreshed
             continue
         plex_id = PF.GetPlexKeyNumber(message['Activity']['Context']['key'])[1]

--- a/resources/lib/sync.py
+++ b/resources/lib/sync.py
@@ -229,7 +229,8 @@ class Sync(backgroundthread.KillableThread):
                     # this once a while (otherwise, potentially many screen
                     # refreshes lead to flickering)
                     if (library_sync.WEBSOCKET_MESSAGES and
-                            now - last_websocket_processing > 5):
+                            now - last_websocket_processing > 5 and 
+                            (utils.settings('delayBackgroundSyncWhilePlaying') == "false" or not app.APP.is_playing_video)):
                         last_websocket_processing = now
                         library_sync.process_websocket_messages()
                     # See if there is a PMS message we need to handle

--- a/resources/lib/sync.py
+++ b/resources/lib/sync.py
@@ -229,7 +229,7 @@ class Sync(backgroundthread.KillableThread):
                     # this once a while (otherwise, potentially many screen
                     # refreshes lead to flickering)
                     if (library_sync.WEBSOCKET_MESSAGES and
-                            now - last_websocket_processing > 5 and 
+                            now - last_websocket_processing > 5 and
                             (utils.settings('delayBackgroundSyncWhilePlaying') == "false" or not app.APP.is_playing_video)):
                         last_websocket_processing = now
                         library_sync.process_websocket_messages()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -78,6 +78,7 @@
         <setting type="lsep" label="39052" /><!-- Background Sync -->
         <setting id="enableBackgroundSync" type="bool" label="39026" default="true" visible="true"/>
         <setting id="backgroundsync_saftyMargin" type="slider" label="39051" default="5" option="int" range="5,1,300" visible="eq(-1,true)" subsetting="true" />
+        <setting id="delayBackgroundSyncWhilePlaying" type="bool" label="39027" default="false" visible="eq(-2,true)"/>
         <setting type="sep" />
         <setting type="lsep" label="30538" /><!-- Manual complete reset of Kodi database necessary, see "Advanced" -->
         <setting id="showExtrasInsteadOfTrailer" type="bool" label="30514" default="false" /><!-- Show all Plex extras instead of immediately playing trailers -->


### PR DESCRIPTION
This is a follow up on #2027. While that change works, I still want to prevent background sync library refreshes (due to new media being added) from happening while playing videos. 

The scheduled full sync code prevents it from running while videos are playing ([link](https://github.com/croneter/PlexKodiConnect/blob/1d4d3e72fed641668921e72825ae6600abdcd162/resources/lib/sync.py#L223C1-L224C55)). I think we should allow the same for background sync.

Changes:
- Add a `Delay background sync while media is playing` setting to enable similar functionality for the background sync flow. It will essentially keep storing websocket messages and process them once you are no longer playing a video. 
- Make the check for the `refreshed` property a little safer. I saw an error in my logs related to this.