### PR TITLE
Add support for Plex Watchlist

### DIFF
--- a/default.py
+++ b/default.py
@@ -86,6 +86,8 @@ def triage(mode, params, path, arguments, itemid):
             entrypoint.show_section(params.get('section_index'))
         elif mode == 'watchlater':
             entrypoint.watchlater()
+        elif mode == 'watchlist':
+            entrypoint.watchlist()
         elif mode == 'channels':
             entrypoint.browse_plex(key='/channels/all')
         elif mode == 'search':

--- a/default.py
+++ b/default.py
@@ -87,7 +87,7 @@ def triage(mode, params, path, arguments, itemid):
         elif mode == 'watchlater':
             entrypoint.watchlater()
         elif mode == 'watchlist':
-            entrypoint.watchlist()
+            entrypoint.watchlist(section_id=params.get('section_id'))
         elif mode == 'channels':
             entrypoint.browse_plex(key='/channels/all')
         elif mode == 'search':

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1231,6 +1231,10 @@ msgctxt "#39211"
 msgid "Watch later"
 msgstr ""
 
+msgctxt "#39212"
+msgid "Watchlist"
+msgstr ""
+
 # Error message pop-up if {0} cannot be contacted. {0} will be replaced by e.g. the PMS' name
 msgctxt "#39213"
 msgid "{0} offline"

--- a/resources/lib/entrypoint.py
+++ b/resources/lib/entrypoint.py
@@ -205,7 +205,7 @@ def show_listing(xml, plex_type=None, section_id=None, synched=True, key=None):
         return
     api = API(xml[0])
     # Determine content type for Kodi's Container.content
-    if key == '/hubs/home/continueWatching':
+    if key == '/hubs/home/continueWatching' or key == 'watchlist':
         # Mix of movies and episodes
         plex_type = v.PLEX_TYPE_VIDEO
     elif key == '/hubs/home/recentlyAdded?type=2':
@@ -256,6 +256,10 @@ def show_listing(xml, plex_type=None, section_id=None, synched=True, key=None):
     if key == "watchlist":
         # filter out items that are not in the kodi db (items that will not be playable)
         all_items = [item for item in all_items if item.kodi_id is not None]
+
+        # filter out items in the wrong section id when it's specified
+        if section_id is not None:
+            all_items = [item for item in all_items if item.section_id == utils.cast(int, section_id)]
 
     all_items = [widgets.generate_item(api) for api in all_items]
     all_items = [widgets.prepare_listitem(item) for item in all_items]
@@ -475,7 +479,7 @@ def watchlater():
     show_listing(xml)
 
 
-def watchlist():
+def watchlist(section_id=None):
     """
     Listing for plex.tv Watchlist section (if signed in to plex.tv)
     """
@@ -495,7 +499,7 @@ def watchlist():
     except (TypeError, IndexError, AttributeError):
         LOG.error('Could not download watch list list from plex.tv')
         raise ListingException
-    show_listing(xml, None, None, False, "watchlist")
+    show_listing(xml, None, section_id, False, "watchlist")
 
 
 def browse_plex(key=None, plex_type=None, section_id=None, synched=True,

--- a/resources/lib/entrypoint.py
+++ b/resources/lib/entrypoint.py
@@ -151,10 +151,12 @@ def show_main_menu(content_type=None):
         directory_item(utils.lang(136), path)
     # Plex Search "Search"
     directory_item(utils.lang(137), "plugin://%s?mode=search" % v.ADDON_ID)
-    # Plex Watch later
+    # Plex Watch later and Watchlist
     if content_type not in ('image', 'audio'):
         directory_item(utils.lang(39211),
                        "plugin://%s?mode=watchlater" % v.ADDON_ID)
+        directory_item(utils.lang(39212),
+                       "plugin://%s?mode=watchlist" % v.ADDON_ID)
     # Plex Channels
     directory_item(utils.lang(30173), "plugin://%s?mode=channels" % v.ADDON_ID)
     # Plex user switch
@@ -250,6 +252,11 @@ def show_listing(xml, plex_type=None, section_id=None, synched=True, key=None):
         widgets.KEY = key
     # Process all items to show
     all_items = mass_api(xml)
+
+    if key == "watchlist":
+        # filter out items that are not in the kodi db (items that will not be playable)
+        all_items = [item for item in all_items if item.kodi_id is not None]
+
     all_items = [widgets.generate_item(api) for api in all_items]
     all_items = [widgets.prepare_listitem(item) for item in all_items]
     # fill that listing...
@@ -466,6 +473,29 @@ def watchlater():
         LOG.error('Could not download watch later list from plex.tv')
         raise ListingException
     show_listing(xml)
+
+
+def watchlist():
+    """
+    Listing for plex.tv Watchlist section (if signed in to plex.tv)
+    """
+    _wait_for_auth()
+    if utils.window('plex_token') == '':
+        LOG.error('No watchlist - not signed in to plex.tv')
+        raise ListingException
+    if utils.window('plex_restricteduser') == 'true':
+        LOG.error('No watchlist - restricted user')
+        raise ListingException
+    app.init(entrypoint=True)
+    xml = DU().downloadUrl('https://metadata.provider.plex.tv/library/sections/watchlist/all',
+                           authenticate=False,
+                           headerOptions={'X-Plex-Token': utils.window('plex_token')})  
+    try:
+        xml[0].attrib
+    except (TypeError, IndexError, AttributeError):
+        LOG.error('Could not download watch list list from plex.tv')
+        raise ListingException
+    show_listing(xml, None, None, False, "watchlist")
 
 
 def browse_plex(key=None, plex_type=None, section_id=None, synched=True,

--- a/resources/lib/entrypoint.py
+++ b/resources/lib/entrypoint.py
@@ -489,7 +489,7 @@ def watchlist():
     app.init(entrypoint=True)
     xml = DU().downloadUrl('https://metadata.provider.plex.tv/library/sections/watchlist/all',
                            authenticate=False,
-                           headerOptions={'X-Plex-Token': utils.window('plex_token')})  
+                           headerOptions={'X-Plex-Token': utils.window('plex_token')})
     try:
         xml[0].attrib
     except (TypeError, IndexError, AttributeError):

--- a/resources/lib/itemtypes/movies.py
+++ b/resources/lib/itemtypes/movies.py
@@ -38,6 +38,7 @@ class Movie(ItemBase):
                       section_id or api.library_section_id())
             return
         plex_id = api.plex_id
+        plex_guid = api.plex_guid
         movie = self.plexdb.movie(plex_id)
         if movie:
             update_item = True
@@ -168,6 +169,7 @@ class Movie(ItemBase):
                                api.viewcount(),
                                api.lastplayed())
         self.plexdb.add_movie(plex_id=plex_id,
+                              plex_guid=plex_guid,
                               checksum=api.checksum(),
                               section_id=section_id,
                               kodi_id=kodi_id,

--- a/resources/lib/itemtypes/tvshows.py
+++ b/resources/lib/itemtypes/tvshows.py
@@ -153,6 +153,7 @@ class Show(TvShowMixin, ItemBase):
                       section_id or api.library_section_id())
             return
         plex_id = api.plex_id
+        plex_guid = api.plex_guid
         show = self.plexdb.show(plex_id)
         if not show:
             update_item = False
@@ -253,6 +254,7 @@ class Show(TvShowMixin, ItemBase):
         tags.extend([i for _, i in api.collections()])
         self.kodidb.modify_tags(kodi_id, v.KODI_TYPE_SHOW, tags)
         self.plexdb.add_show(plex_id=plex_id,
+                             plex_guid=plex_guid,
                              checksum=api.checksum(),
                              section_id=section_id,
                              kodi_id=kodi_id,
@@ -283,6 +285,7 @@ class Season(TvShowMixin, ItemBase):
                       section_id or api.library_section_id())
             return
         plex_id = api.plex_id
+        plex_guid = api.plex_guid
         season = self.plexdb.season(plex_id)
         if not season:
             update_item = False
@@ -340,6 +343,7 @@ class Season(TvShowMixin, ItemBase):
                                         kodi_id,
                                         v.KODI_TYPE_SEASON)
         self.plexdb.add_season(plex_id=plex_id,
+                               plex_guid=plex_guid,
                                checksum=api.checksum(),
                                section_id=section_id,
                                show_id=show_id,
@@ -361,6 +365,7 @@ class Episode(TvShowMixin, ItemBase):
                       section_id or api.library_section_id())
             return
         plex_id = api.plex_id
+        plex_guid = api.plex_guid
         episode = self.plexdb.episode(plex_id)
         if not episode:
             update_item = False
@@ -496,6 +501,7 @@ class Episode(TvShowMixin, ItemBase):
                                        api.viewcount(),
                                        api.lastplayed())
             self.plexdb.add_episode(plex_id=plex_id,
+                                    plex_guid=plex_guid,
                                     checksum=api.checksum(),
                                     section_id=section_id,
                                     show_id=api.show_id(),
@@ -566,6 +572,7 @@ class Episode(TvShowMixin, ItemBase):
                                        api.viewcount(),
                                        api.lastplayed())
             self.plexdb.add_episode(plex_id=plex_id,
+                                    plex_guid=plex_guid,
                                     checksum=api.checksum(),
                                     section_id=section_id,
                                     show_id=api.show_id(),

--- a/resources/lib/library_sync/nodes.py
+++ b/resources/lib/library_sync/nodes.py
@@ -88,6 +88,14 @@ NODE_TYPES = {
               'section_id': '{self.section_id}'
          },
          v.CONTENT_TYPE_MOVIE),
+        ('watchlist',
+         utils.lang(39212),  # "Watchlist"
+         {
+              'mode': 'watchlist',
+              'key': '/library/sections/{self.section_id}/watchlist',
+              'section_id': '{self.section_id}'
+         },
+         v.CONTENT_TYPE_MOVIE),
         ('browse',
          utils.lang(39702),  # "Browse by folder"
          {
@@ -175,6 +183,14 @@ NODE_TYPES = {
               'section_id': '{self.section_id}'
          },
          v.CONTENT_TYPE_EPISODE),
+        ('watchlist',
+         utils.lang(39212),  # "Watchlist"
+         {
+              'mode': 'watchlist',
+              'key': '/library/sections/{self.section_id}/watchlist',
+              'section_id': '{self.section_id}'
+         },
+         v.CONTENT_TYPE_SHOW),
         ('browse',
          utils.lang(39702),  # "Browse by folder"
          {
@@ -391,3 +407,8 @@ def node_more(section, node_name, args):
 
 def node_plex_sets(section, node_name, args):
     return _folder_template(section, node_name, args)
+
+
+def node_watchlist(section, node_name, args):
+    return _folder_template(section, node_name, args)
+

--- a/resources/lib/plex_db/common.py
+++ b/resources/lib/plex_db/common.py
@@ -119,7 +119,7 @@ class PlexDBBase(object):
         else:
             pass
         return answ
-    
+
     def item_by_kodi_id(self, kodi_id, kodi_type):
         """
         """

--- a/resources/lib/plex_db/common.py
+++ b/resources/lib/plex_db/common.py
@@ -92,6 +92,34 @@ class PlexDBBase(object):
                     break
         return answ
 
+    def item_by_guid(self, plex_guid, plex_type=None):
+        """
+        Returns the item for plex_guid or None.
+        Supply with the correct plex_type to speed up lookup
+        """
+        answ = None
+        if plex_type == v.PLEX_TYPE_MOVIE:
+            answ = self.movie_by_guid(plex_guid)
+        elif plex_type == v.PLEX_TYPE_EPISODE:
+            answ = self.episode_by_guid(plex_guid)
+        elif plex_type == v.PLEX_TYPE_SHOW:
+            answ = self.show_by_guid(plex_guid)
+        elif plex_type == v.PLEX_TYPE_SEASON:
+            answ = self.season_by_guid(plex_guid)
+        elif plex_type is None:
+            # SLOW - lookup plex_id in all our tables
+            for kind in (v.PLEX_TYPE_MOVIE,
+                         v.PLEX_TYPE_EPISODE,
+                         v.PLEX_TYPE_SHOW,
+                         v.PLEX_TYPE_SEASON):
+                method = getattr(self, kind + "_by_guid")
+                answ = method(plex_guid)
+                if answ:
+                    break
+        else:
+            pass
+        return answ
+    
     def item_by_kodi_id(self, kodi_id, kodi_type):
         """
         """
@@ -223,6 +251,7 @@ def initialize():
             plexdb.cursor.execute('''
                 CREATE TABLE IF NOT EXISTS movie(
                     plex_id INTEGER PRIMARY KEY,
+                    plex_guid TEXT,
                     checksum INTEGER UNIQUE,
                     section_id INTEGER,
                     kodi_id INTEGER,
@@ -235,6 +264,7 @@ def initialize():
             plexdb.cursor.execute('''
                 CREATE TABLE IF NOT EXISTS show(
                     plex_id INTEGER PRIMARY KEY,
+                    plex_guid TEXT,
                     checksum INTEGER UNIQUE,
                     section_id INTEGER,
                     kodi_id INTEGER,
@@ -245,6 +275,7 @@ def initialize():
             plexdb.cursor.execute('''
                 CREATE TABLE IF NOT EXISTS season(
                     plex_id INTEGER PRIMARY KEY,
+                    plex_guid TEXT,
                     checksum INTEGER UNIQUE,
                     section_id INTEGER,
                     show_id INTEGER,
@@ -256,6 +287,7 @@ def initialize():
             plexdb.cursor.execute('''
                 CREATE TABLE IF NOT EXISTS episode(
                     plex_id INTEGER PRIMARY KEY,
+                    plex_guid TEXT,
                     checksum INTEGER UNIQUE,
                     section_id INTEGER,
                     show_id INTEGER,
@@ -313,12 +345,16 @@ def initialize():
             commands = (
                 'CREATE INDEX IF NOT EXISTS ix_movie_1 ON movie (last_sync)',
                 'CREATE UNIQUE INDEX IF NOT EXISTS ix_movie_2 ON movie (kodi_id)',
+                'CREATE UNIQUE INDEX IF NOT EXISTS ix_movie_3 ON movie (plex_guid)',
                 'CREATE INDEX IF NOT EXISTS ix_show_1 ON show (last_sync)',
                 'CREATE UNIQUE INDEX IF NOT EXISTS ix_show_2 ON show (kodi_id)',
+                'CREATE UNIQUE INDEX IF NOT EXISTS ix_show_3 ON show (plex_guid)',
                 'CREATE INDEX IF NOT EXISTS ix_season_1 ON season (last_sync)',
                 'CREATE UNIQUE INDEX IF NOT EXISTS ix_season_2 ON season (kodi_id)',
+                'CREATE UNIQUE INDEX IF NOT EXISTS ix_season_3 ON season (plex_guid)',
                 'CREATE INDEX IF NOT EXISTS ix_episode_1 ON episode (last_sync)',
                 'CREATE UNIQUE INDEX IF NOT EXISTS ix_episode_2 ON episode (kodi_id)',
+                'CREATE UNIQUE INDEX IF NOT EXISTS ix_episode_3 ON season (plex_guid)',
                 'CREATE INDEX IF NOT EXISTS ix_artist_1 ON artist (last_sync)',
                 'CREATE UNIQUE INDEX IF NOT EXISTS ix_artist_2 ON artist (kodi_id)',
                 'CREATE INDEX IF NOT EXISTS ix_album_1 ON album (last_sync)',

--- a/resources/lib/plex_db/movies.py
+++ b/resources/lib/plex_db/movies.py
@@ -4,7 +4,7 @@ from .. import variables as v
 
 
 class Movies(object):
-    def add_movie(self, plex_id, checksum, section_id, kodi_id, kodi_fileid,
+    def add_movie(self, plex_id, plex_guid, checksum, section_id, kodi_id, kodi_fileid,
                   kodi_pathid, trailer_synced, last_sync):
         """
         Appends or replaces an entry into the plex table for movies
@@ -12,6 +12,7 @@ class Movies(object):
         query = '''
             INSERT OR REPLACE INTO movie(
                 plex_id,
+                plex_guid,
                 checksum,
                 section_id,
                 kodi_id,
@@ -20,11 +21,12 @@ class Movies(object):
                 fanart_synced,
                 trailer_synced,
                 last_sync)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             '''
         self.cursor.execute(
             query,
             (plex_id,
+             plex_guid,
              checksum,
              section_id,
              kodi_id,
@@ -38,6 +40,7 @@ class Movies(object):
         """
         Returns the show info as a tuple for the TV show with plex_id:
             plex_id INTEGER PRIMARY KEY ASC,
+            plex_guid TEXT,
             checksum INTEGER UNIQUE,
             section_id INTEGER,
             kodi_id INTEGER,
@@ -52,6 +55,25 @@ class Movies(object):
                             (plex_id, ))
         return self.entry_to_movie(self.cursor.fetchone())
 
+    def movie_by_guid(self, plex_guid):
+        """
+        Returns the show info as a tuple for the TV show with plex_guid:
+            plex_id INTEGER PRIMARY KEY ASC,
+            plex_guid TEXT,
+            checksum INTEGER UNIQUE,
+            section_id INTEGER,
+            kodi_id INTEGER,
+            kodi_fileid INTEGER,
+            kodi_pathid INTEGER,
+            fanart_synced INTEGER,
+            last_sync INTEGER
+        """
+        if plex_guid is None:
+            return
+        self.cursor.execute('SELECT * FROM movie WHERE plex_guid = ? LIMIT 1',
+                            (plex_guid, ))
+        return self.entry_to_movie(self.cursor.fetchone())
+
     @staticmethod
     def entry_to_movie(entry):
         if not entry:
@@ -60,11 +82,12 @@ class Movies(object):
             'plex_type': v.PLEX_TYPE_MOVIE,
             'kodi_type': v.KODI_TYPE_MOVIE,
             'plex_id': entry[0],
-            'checksum': entry[1],
-            'section_id': entry[2],
-            'kodi_id': entry[3],
-            'kodi_fileid': entry[4],
-            'kodi_pathid': entry[5],
-            'fanart_synced': entry[6],
-            'last_sync': entry[7]
+            'plex_guid': entry[1],
+            'checksum': entry[2],
+            'section_id': entry[3],
+            'kodi_id': entry[4],
+            'kodi_fileid': entry[5],
+            'kodi_pathid': entry[6],
+            'fanart_synced': entry[7],
+            'last_sync': entry[8]
         }

--- a/resources/lib/plex_db/tvshows.py
+++ b/resources/lib/plex_db/tvshows.py
@@ -3,7 +3,7 @@
 from .. import variables as v
 
 class TVShows(object):
-    def add_show(self, plex_id, checksum, section_id, kodi_id, kodi_pathid,
+    def add_show(self, plex_id, plex_guid, checksum, section_id, kodi_id, kodi_pathid,
                  last_sync):
         """
         Appends or replaces tv show entry into the plex table
@@ -12,15 +12,17 @@ class TVShows(object):
             '''
             INSERT OR REPLACE INTO show(
                 plex_id,
+                plex_guid,
                 checksum,
                 section_id,
                 kodi_id,
                 kodi_pathid,
                 fanart_synced,
                 last_sync)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ''',
             (plex_id,
+             plex_guid,
              checksum,
              section_id,
              kodi_id,
@@ -28,7 +30,7 @@ class TVShows(object):
              0,
              last_sync))
 
-    def add_season(self, plex_id, checksum, section_id, show_id, parent_id,
+    def add_season(self, plex_id, plex_guid, checksum, section_id, show_id, parent_id,
                    kodi_id, last_sync):
         """
         Appends or replaces an entry into the plex table
@@ -37,6 +39,7 @@ class TVShows(object):
             '''
             INSERT OR REPLACE INTO season(
                 plex_id,
+                plex_guid,
                 checksum,
                 section_id,
                 show_id,
@@ -44,9 +47,10 @@ class TVShows(object):
                 kodi_id,
                 fanart_synced,
                 last_sync)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''',
             (plex_id,
+             plex_guid,
              checksum,
              section_id,
              show_id,
@@ -55,7 +59,7 @@ class TVShows(object):
              0,
              last_sync))
 
-    def add_episode(self, plex_id, checksum, section_id, show_id,
+    def add_episode(self, plex_id, plex_guid, checksum, section_id, show_id,
                     grandparent_id, season_id, parent_id, kodi_id, kodi_fileid,
                     kodi_fileid_2, kodi_pathid, last_sync):
         """
@@ -65,6 +69,7 @@ class TVShows(object):
             '''
             INSERT OR REPLACE INTO episode(
                 plex_id,
+                plex_guid,
                 checksum,
                 section_id,
                 show_id,
@@ -77,9 +82,10 @@ class TVShows(object):
                 kodi_pathid,
                 fanart_synced,
                 last_sync)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''',
             (plex_id,
+             plex_guid,
              checksum,
              section_id,
              show_id,
@@ -97,6 +103,7 @@ class TVShows(object):
         """
         Returns the show info as a tuple for the TV show with plex_id:
             plex_id INTEGER PRIMARY KEY ASC,
+            plex_guid TEXT,
             checksum INTEGER UNIQUE,
             section_id INTEGER,
             kodi_id INTEGER,
@@ -110,10 +117,29 @@ class TVShows(object):
                             (plex_id, ))
         return self.entry_to_show(self.cursor.fetchone())
 
+    def show_by_guid(self, plex_guid):
+        """
+        Returns the show info as a tuple for the TV show with plex_guid:
+            plex_id INTEGER PRIMARY KEY ASC,
+            plex_guid TEXT,
+            checksum INTEGER UNIQUE,
+            section_id INTEGER,
+            kodi_id INTEGER,
+            kodi_pathid INTEGER,
+            fanart_synced INTEGER,
+            last_sync INTEGER
+        """
+        if plex_guid is None:
+            return
+        self.cursor.execute('SELECT * FROM show WHERE plex_guid = ? LIMIT 1',
+                            (plex_guid, ))
+        return self.entry_to_show(self.cursor.fetchone())
+
     def season(self, plex_id):
         """
         Returns the show info as a tuple for the TV show with plex_id:
             plex_id INTEGER PRIMARY KEY,
+            plex_guid TEXT,
             checksum INTEGER UNIQUE,
             section_id INTEGER,
             show_id INTEGER,  # plex_id of the parent show
@@ -128,11 +154,37 @@ class TVShows(object):
                             (plex_id, ))
         return self.entry_to_season(self.cursor.fetchone())
 
+    def season_by_guid(self, plex_guid):
+        """
+        Returns the show info as a tuple for the TV show with plex_guid:
+            plex_id INTEGER PRIMARY KEY,
+            plex_guid TEXT,
+            checksum INTEGER UNIQUE,
+            section_id INTEGER,
+            show_id INTEGER,  # plex_id of the parent show
+            parent_id INTEGER,  # kodi_id of the parent show
+            kodi_id INTEGER,
+            fanart_synced INTEGER,
+            last_sync INTEGER
+        """
+        if plex_guid is None:
+            return
+        self.cursor.execute('SELECT * FROM season WHERE plex_guid = ? LIMIT 1',
+                            (plex_guid, ))
+        return self.entry_to_season(self.cursor.fetchone())
+
     def episode(self, plex_id):
         if plex_id is None:
             return
         self.cursor.execute('SELECT * FROM episode WHERE plex_id = ? LIMIT 1',
                             (plex_id, ))
+        return self.entry_to_episode(self.cursor.fetchone())
+
+    def episode_by_guid(self, plex_guid):
+        if plex_guid is None:
+            return
+        self.cursor.execute('SELECT * FROM episode WHERE plex_guid = ? LIMIT 1',
+                            (plex_guid, ))
         return self.entry_to_episode(self.cursor.fetchone())
 
     @staticmethod
@@ -143,18 +195,19 @@ class TVShows(object):
             'plex_type': v.PLEX_TYPE_EPISODE,
             'kodi_type': v.KODI_TYPE_EPISODE,
             'plex_id': entry[0],
-            'checksum': entry[1],
-            'section_id': entry[2],
-            'show_id': entry[3],
-            'grandparent_id': entry[4],
-            'season_id': entry[5],
-            'parent_id': entry[6],
-            'kodi_id': entry[7],
-            'kodi_fileid': entry[8],
-            'kodi_fileid_2': entry[9],
-            'kodi_pathid': entry[10],
-            'fanart_synced': entry[11],
-            'last_sync': entry[12]
+            'plex_guid': entry[1],
+            'checksum': entry[2],
+            'section_id': entry[3],
+            'show_id': entry[4],
+            'grandparent_id': entry[5],
+            'season_id': entry[6],
+            'parent_id': entry[7],
+            'kodi_id': entry[8],
+            'kodi_fileid': entry[9],
+            'kodi_fileid_2': entry[10],
+            'kodi_pathid': entry[11],
+            'fanart_synced': entry[12],
+            'last_sync': entry[13]
         }
 
     @staticmethod
@@ -165,12 +218,13 @@ class TVShows(object):
             'plex_type': v.PLEX_TYPE_SHOW,
             'kodi_type': v.KODI_TYPE_SHOW,
             'plex_id': entry[0],
-            'checksum': entry[1],
-            'section_id': entry[2],
-            'kodi_id': entry[3],
-            'kodi_pathid': entry[4],
-            'fanart_synced': entry[5],
-            'last_sync': entry[6]
+            'plex_guid': entry[1],
+            'checksum': entry[2],
+            'section_id': entry[3],
+            'kodi_id': entry[4],
+            'kodi_pathid': entry[5],
+            'fanart_synced': entry[6],
+            'last_sync': entry[7]
         }
 
     @staticmethod
@@ -181,13 +235,14 @@ class TVShows(object):
             'plex_type': v.PLEX_TYPE_SEASON,
             'kodi_type': v.KODI_TYPE_SEASON,
             'plex_id': entry[0],
-            'checksum': entry[1],
-            'section_id': entry[2],
-            'show_id': entry[3],
-            'parent_id': entry[4],
-            'kodi_id': entry[5],
-            'fanart_synced': entry[6],
-            'last_sync': entry[7]
+            'plex_guid': entry[1],
+            'checksum': entry[2],
+            'section_id': entry[3],
+            'show_id': entry[4],
+            'parent_id': entry[5],
+            'kodi_id': entry[6],
+            'fanart_synced': entry[7],
+            'last_sync': entry[8]
         }
 
     def season_has_episodes(self, plex_id):


### PR DESCRIPTION
Addresses: #1828. Explanation below for how this works:

You can check your Plex Watchlist by going to `https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token={token}` (fill out the token param). Here's an example result:
```xml
<?xml version="1.0"?>
<MediaContainer librarySectionID="watchlist" librarySectionTitle="Watchlist" offset="0"
    totalSize="32" identifier="tv.plex.provider.metadata" size="20">
    <Video art="https://metadata-static.plex.tv/5/gracenote/5d3ffdbcdf1e8c07cffff3aad36ac0ce.jpg"
        banner="http://assets.fanart.tv/fanart/movies/46838/moviebanner/tucker--dale-vs-evil-51ab23d9dab5e.jpg"
        guid="plex://movie/5d776883ebdf2200209c104e"
        key="/library/metadata/5d776883ebdf2200209c104e" rating="8.5"
        ratingKey="5d776883ebdf2200209c104e" studio="Eden Rock Media"
        tagline="Evil just messed with the wrong hillbillies." type="movie"
        thumb="https://metadata-static.plex.tv/c/gracenote/ce5e380d9209dc7fa5fbb8fb3cff9d48.jpg"
        addedAt="1291852800" duration="5340000"
        publicPagesURL="https://watch.plex.tv/movie/tucker-and-dale-vs-evil"
        slug="tucker-and-dale-vs-evil" expiresAt="1713941940" userState="0"
        title="Tucker and Dale vs Evil" contentRating="R" originallyAvailableAt="2010-12-09"
        year="2010" availabilityId="62cf3270700e44e58631846c"
        streamingMediaId="62cf3270700e44e5863182d6" audienceRating="8.5"
        audienceRatingImage="rottentomatoes://image.rating.upright"
        ratingImage="rottentomatoes://image.rating.ripe" imdbRatingCount="192418"
        playableKey="provider://tv.plex.provider.vod/library/metadata/5d776883ebdf2200209c104e">
        ...
    </Video>
    <Video art="https://metadata-static.plex.tv/9/gracenote/91e174f0c46ea20c58192bfef5aa6f1e.jpg"
        guid="plex://movie/6310ea4493df84910ae108a2"
        key="/library/metadata/6310ea4493df84910ae108a2" rating="9.1"
        ratingKey="6310ea4493df84910ae108a2" studio="A24" tagline="Meet the man of your dreams."
        type="movie"
        thumb="https://metadata-static.plex.tv/6/gracenote/6b1ab0cb7db6d33b6de803e22d1db37b.jpg"
        addedAt="1699574400" duration="6120000"
        publicPagesURL="https://watch.plex.tv/movie/dream-scenario-2" slug="dream-scenario-2"
        expiresAt="1709942340" userState="0" title="Dream Scenario" contentRating="R"
        originallyAvailableAt="2023-11-10" year="2023" audienceRating="6.8"
        audienceRatingImage="rottentomatoes://image.rating.upright"
        ratingImage="rottentomatoes://image.rating.ripe" imdbRatingCount="39881">
        ...
    </Video>
    ...
```

Each `Video` element includes a guid. This is also known as a 'plex media key' in [wiki land](https://www.wikidata.org/wiki/Wikidata:Property_proposal/Plex_GUID) and every movie, TV show, TV season, & TV episode will have a unique guid assigned to it.

It's important to note that there is no `id` in the `Video` element and the `key`/`ratingKey` do not point to a key on your server (e.g. it's not like `/library/metadata/123`). This means that you cannot directly map the items in this response into your local server without changing the lookup strategy. My understanding is that lookups should use the guid instead.

Based on that, when we want to view the Watchlist in Kodi, we need to map the items from that Watchlist response into items that were synced into Kodi. We can do that by looking up items in the plex db based on that guid. The flow would be:
`Watchlist Video.guid -> Plex DB lookup by guid -> Kodi item`

This requires the addition of a new guid column in the plex db, which requires a database reset/recreation. I also added new indexes for that column to enable quick lookups.

The end result is that the Watchlist will sync correctly and show items that are available in Kodi.

Some pictures:

My watchlist on plex web:
![2024-03-03_17-22-25](https://github.com/croneter/PlexKodiConnect/assets/824323/37a6924a-7a49-4447-9a54-2de306dc4d11)

Me, about to add the watchlist to my home page in arctic fuse skin. It shows up alongside search, channels, watch later:
![image](https://github.com/croneter/PlexKodiConnect/assets/824323/fbb58566-ae68-4ac6-b989-64f5256ac609)

The watchlist items showing up on my home screen. Each item correctly points to the kodi item and is playable
![image](https://github.com/croneter/PlexKodiConnect/assets/824323/ac76aba9-38cf-4575-a393-664b30af4733)

