### PR TITLE
Fix getVideoInfoTag error

### DIFF
--- a/resources/lib/widgets.py
+++ b/resources/lib/widgets.py
@@ -472,6 +472,9 @@ def create_listitem(item, as_tuple=True, offscreen=True,
                     listitem=xbmcgui.ListItem):
     """helper to create a kodi listitem from kodi compatible dict with mediainfo"""
     try:
+        # PKCListItem does not implement getVideoInfoTag
+        use_tags_for_item = USE_TAGS and listitem == xbmcgui.ListItem
+
         liz = listitem(
             label=item.get("label", ""),
             label2=item.get("label2", ""),
@@ -493,7 +496,7 @@ def create_listitem(item, as_tuple=True, offscreen=True,
         # extra properties
         for key, value in item["extraproperties"].items():
             # some Video properties should be set via tags on newer kodi versions
-            if nodetype != "Video" or not USE_TAGS or key not in TAG_PROPERTIES:
+            if nodetype != "Video" or not use_tags_for_item or key not in TAG_PROPERTIES:
                 liz.setProperty(key, value)
 
         # video infolabels
@@ -539,7 +542,7 @@ def create_listitem(item, as_tuple=True, offscreen=True,
 
             # streamdetails
             if item.get("streamdetails"):
-                if USE_TAGS:
+                if use_tags_for_item:
                     tags = liz.getVideoInfoTag()
                     tags.addVideoStream(_create_VideoStreamDetail(item["streamdetails"].get("video", {})))
                     tags.addAudioStream(_create_AudioStreamDetail(item["streamdetails"].get("audio", {})))
@@ -555,7 +558,7 @@ def create_listitem(item, as_tuple=True, offscreen=True,
             if "date" in item:
                 infolabels["date"] = item["date"]
 
-            if USE_TAGS and "resumetime" in item["extraproperties"] and "totaltime" in item["extraproperties"]:
+            if use_tags_for_item and "resumetime" in item["extraproperties"] and "totaltime" in item["extraproperties"]:
                 tags = liz.getVideoInfoTag()
                 tags.setResumePoint(float(item["extraproperties"].get("resumetime")), float(item["extraproperties"].get("totaltime")));
 
@@ -598,7 +601,7 @@ def create_listitem(item, as_tuple=True, offscreen=True,
             infolabels["lastplayed"] = item["lastplayed"]
 
         # assign the infolabels
-        if USE_TAGS and nodetype == "Video":
+        if use_tags_for_item and nodetype == "Video":
             # filter out None valued properties
             infolabels = {k: v for k, v in infolabels.items() if v is not None}
 


### PR DESCRIPTION
Fixes #2050

The `PKCListItem` object does not implement `getVideoInfoTag` ([link](https://github.com/croneter/PlexKodiConnect/blob/f76c4dddab544503d5f6f4182c1dec53213d25fe/resources/lib/transfer.py#L261))

This PR updates the logic to skip calling `getVideoInfoTag` for this case. I don't have a local repro for this, but it should work