### PR TITLE
Automatically hide the skip button after some time

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1535,3 +1535,13 @@ msgstr ""
 msgctxt "#39722"
 msgid "Auto skip commercials"
 msgstr ""
+
+# PKC Settings - Playback
+msgctxt "#39723"
+msgid "Auto hide skip button"
+msgstr ""
+
+# PKC Settings - Playback
+msgctxt "#39724"
+msgid "Seconds until skip button is hidden"
+msgstr ""

--- a/resources/lib/app/playstate.py
+++ b/resources/lib/app/playstate.py
@@ -35,6 +35,7 @@ class PlayState(object):
         'playcount': None,
         'external_player': False,  # bool - xbmc.Player().isExternalPlayer()
         'markers': [],
+        'markers_hidden': {},
         'first_credits_marker': None,
         'final_credits_marker': None
     }

--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -336,6 +336,7 @@ class KodiMonitor(xbmc.Monitor):
                 or utils.settings('enableSkipCredits') == 'true' \
                 or utils.settings('enableSkipCommercials') == 'true':
             status['markers'] = item.api.markers()
+            status['markers_hidden'] = {}
             if utils.settings('enableSkipCredits') == 'true':
                 status['first_credits_marker'] = item.api.first_credits_marker()
                 status['final_credits_marker'] = item.api.final_credits_marker()

--- a/resources/lib/skip_plex_markers.py
+++ b/resources/lib/skip_plex_markers.py
@@ -31,6 +31,8 @@ def skip_markers(markers, markers_hidden):
             del markers_hidden[typus]
     if within_marker is not None:
         if within_marker in markers_hidden:
+            # the user did not click the button within the enableAutoHideSkipTime time
+            # so it was hidden. don't show this marker
             return
 
         if app.APP.skip_markers_dialog is None:

--- a/resources/lib/skip_plex_markers.py
+++ b/resources/lib/skip_plex_markers.py
@@ -12,37 +12,55 @@ MARKERS = {
     'commercial': (utils.lang(30530), 'enableSkipCommercials', 'enableAutoSkipCommercials'),  # Skip commercial
 }
 
-def skip_markers(markers):
+def skip_markers(markers, markers_hidden):
     try:
         progress = app.APP.player.getTime()
     except RuntimeError:
         # XBMC is not playing any media file yet
         return
-    within_marker = False
+    within_marker = None
     marker_definition = None
     for start, end, typus, _ in markers:
         marker_definition = MARKERS[typus]
         if utils.settings(marker_definition[1]) == "true" and start <= progress < end:
-            within_marker = True
+            within_marker = typus
             break
-    if within_marker and app.APP.skip_markers_dialog is None:
-        # WARNING: This Dialog only seems to work if called from the main
-        # thread. Otherwise, onClick and onAction won't work
-        app.APP.skip_markers_dialog = SkipMarkerDialog(
-            'script-plex-skip_marker.xml',
-            v.ADDON_PATH,
-            'default',
-            '1080i',
-            marker_message=marker_definition[0],
-            marker_end=end)
-        if utils.settings(marker_definition[2]) == "true":
-            app.APP.skip_markers_dialog.seekTimeToEnd()
-        else:
-            app.APP.skip_markers_dialog.show()
-    elif not within_marker and app.APP.skip_markers_dialog is not None:
+        elif typus in markers_hidden:
+            # reset the marker when escaping its time window
+            # this allows the skip button to show again if you rewind
+            del markers_hidden[typus]
+    if within_marker is not None:
+        if within_marker in markers_hidden:
+            return
+
+        if app.APP.skip_markers_dialog is None:
+            # WARNING: This Dialog only seems to work if called from the main
+            # thread. Otherwise, onClick and onAction won't work
+            app.APP.skip_markers_dialog = SkipMarkerDialog(
+                'script-plex-skip_marker.xml',
+                v.ADDON_PATH,
+                'default',
+                '1080i',
+                marker_message=marker_definition[0],
+                marker_end=end,
+                creation_time=progress)
+            if utils.settings(marker_definition[2]) == "true":
+                app.APP.skip_markers_dialog.seekTimeToEnd()
+            else:
+                app.APP.skip_markers_dialog.show()
+
+        elif utils.settings("enableAutoHideSkip") == "true" and \
+            app.APP.skip_markers_dialog.creation_time is not None and \
+            (progress - app.APP.skip_markers_dialog.creation_time) > int(utils.settings("enableAutoHideSkipTime")):
+            # the dialog has been open for more than X seconds, so close it and
+            # mark it as hidden so it won't show up again within the start/end window
+            markers_hidden[within_marker] = True
+            app.APP.skip_markers_dialog.close()
+            app.APP.skip_markers_dialog = None
+
+    elif app.APP.skip_markers_dialog is not None:
         app.APP.skip_markers_dialog.close()
         app.APP.skip_markers_dialog = None
-
 
 def check():
     with app.APP.lock_playqueues:
@@ -50,6 +68,7 @@ def check():
             return
         playerid = list(app.PLAYSTATE.active_players)[0]
         markers = app.PLAYSTATE.player_states[playerid]['markers']
+        markers_hidden = app.PLAYSTATE.player_states[playerid]['markers_hidden']
     if not markers:
         return
-    skip_markers(markers)
+    skip_markers(markers, markers_hidden)

--- a/resources/lib/windows/skip_marker.py
+++ b/resources/lib/windows/skip_marker.py
@@ -20,6 +20,7 @@ class SkipMarkerDialog(WindowXMLDialog):
         self.marker_message = kwargs.pop('marker_message')
         self.setProperty('marker_message', self.marker_message)
         self.marker_end = kwargs.pop('marker_end', None)
+        self.creation_time = kwargs.pop('creation_time', None)
 
         log.debug('SkipMarkerDialog with message %s, ends at %s',
                   self.marker_message, self.marker_end)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -120,6 +120,8 @@
         <setting id="enableAutoSkipCredits" type="bool" label="39721" default="false" visible="eq(-1,true)" subsetting="true" /><!-- Enable auto skipping of credits -->
         <setting id="enableSkipCommercials" type="bool" label="30530" default="true" /><!-- Enable skipping of commercials -->
         <setting id="enableAutoSkipCommercials" type="bool" label="39722" default="false" visible="eq(-1,true)" subsetting="true" /><!-- Enable auto skipping of commercials -->
+        <setting id="enableAutoHideSkip" type="bool" label="39723" default="true" /><!-- Enable hiding skip button after some time -->
+        <setting id="enableAutoHideSkipTime" type="slider" label="39724" option="int" range="1,1,60" default="10" visible="eq(-1,true)" subsetting="true" /><!-- Seconds til the skip button should be hidden-->
         <setting id="firstVideoStream" type="bool" label="30546" default="false" /><!-- Pick the first video if several versions are present -->
         <setting id="audioStreamPick" type="enum" label="30547" values="Plex|Kodi" default="0" /><!-- Who picks the audio stream on playback start? -->
         <setting id="subtitleStreamPick" type="enum" label="30548" values="Plex|Kodi" default="0" /><!-- Who picks subtitles on playback start? -->


### PR DESCRIPTION
Plex apps automatically hide the skip intro/credits button after 10 seconds. This PR adds the same logic to PKC.

The new setting allows you to turn this on and off and also allows adjusting the 10 second time. I have it defaulting to enabled since the Plex apps enable this by default.

![2024-03-28_18-59-47](https://github.com/croneter/PlexKodiConnect/assets/824323/bc797c4f-0b18-4696-8449-a48ba3957d7c)
