### PR TITLE
Sync Plex Labels

### DIFF
--- a/resources/lib/itemtypes/movies.py
+++ b/resources/lib/itemtypes/movies.py
@@ -159,7 +159,9 @@ class Movie(ItemBase):
 
         self.kodidb.modify_streams(file_id, api.mediastreams(), api.runtime())
         self.kodidb.modify_studios(kodi_id, v.KODI_TYPE_MOVIE, api.studios())
+        # Process tags: section, PMS labels, PMS collection tags
         tags = [section_name]
+        tags.extend(api.labels())
         self._process_collections(api, tags, kodi_id, section_id, children)
         self.kodidb.modify_tags(kodi_id, v.KODI_TYPE_MOVIE, tags)
         # Process playstate

--- a/resources/lib/itemtypes/tvshows.py
+++ b/resources/lib/itemtypes/tvshows.py
@@ -249,8 +249,9 @@ class Show(TvShowMixin, ItemBase):
         self.kodidb.modify_genres(kodi_id, v.KODI_TYPE_SHOW, api.genres())
         # Process studios
         self.kodidb.modify_studios(kodi_id, v.KODI_TYPE_SHOW, api.studios())
-        # Process tags: view, PMS collection tags
+        # Process tags: section, PMS labels, PMS collection tags
         tags = [section_name]
+        tags.extend(api.labels())
         tags.extend([i for _, i in api.collections()])
         self.kodidb.modify_tags(kodi_id, v.KODI_TYPE_SHOW, tags)
         self.plexdb.add_show(plex_id=plex_id,

--- a/resources/lib/plex_api/base.py
+++ b/resources/lib/plex_api/base.py
@@ -46,6 +46,7 @@ class Base(object):
         self._producers = []
         self._locations = []
         self._markers = []
+        self._labels = []
         self._guids = {}
         self._coll_match = None
         # Plex DB attributes
@@ -547,6 +548,8 @@ class Base(object):
                                       end / 1000.0,
                                       child.get('type'),
                                       child.get('final') == '1'))
+            elif child.tag == 'Label':
+                self._labels.append(child.get('tag'))
         # Plex Movie agent (legacy) or "normal" Plex tv show agent
         if not self._guids:
             guid = self.xml.get('guid')
@@ -647,6 +650,13 @@ class Base(object):
             'director': [(x, ) for x in self._directors],
             'writer': [(x, ) for x in self._writers]
         }
+
+    def labels(self):
+        """
+        Returns a list of labels found
+        """
+        self._scan_children()
+        return self._labels
 
     def extras(self):
         """

--- a/resources/lib/widgets.py
+++ b/resources/lib/widgets.py
@@ -176,7 +176,7 @@ def _generate_content(api):
                 'season': api.season_number(),
                 'sorttitle': api.sorttitle(),  # 'Titans (2018)'
                 'studio': api.studios(),
-                'tag': [],  # List of tags this item belongs to
+                'tag': api.labels(),  # List of tags this item belongs to
                 'tagline': api.tagline(),
                 'thumbnail': '',  # e.g. 'image://https%3a%2f%2fassets.tv'
                 'title': api.title(),  # 'Titans (2018)'
@@ -522,6 +522,7 @@ def create_listitem(item, as_tuple=True, offscreen=True,
                 "sorttitle": item.get("sorttitle"),
                 "duration": item.get("duration"),
                 "studio": item.get("studio"),
+                "tag": item.get("tag"),
                 "tagline": item.get("tagline"),
                 "writer": item.get("writer"),
                 "tvshowtitle": item.get("tvshowtitle"),


### PR DESCRIPTION
PKC currently tags items with the Plex library name & collection name. This PR makes it sync the Plex Labels too.

Resolves #2042