### PR TITLE
Reduce database locking

### DIFF
--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -157,7 +157,7 @@ class KodiMonitor(xbmc.Monitor):
         if not kodi_id and kodi_type and path:
             kodi_id, _ = kodi_db.kodiid_from_filename(path, kodi_type)
         if kodi_id:
-            with PlexDB() as plexdb:
+            with PlexDB(lock=False) as plexdb:
                 db_item = plexdb.item_by_kodi_id(kodi_id, kodi_type)
             if db_item:
                 plex_id = db_item['plex_id']
@@ -419,7 +419,7 @@ def _record_playstate(status, ended):
     if status['plex_type'] not in v.PLEX_VIDEOTYPES:
         LOG.debug('Not messing with non-video entries')
         return
-    with PlexDB() as plexdb:
+    with PlexDB(lock=False) as plexdb:
         db_item = plexdb.item_by_id(status['plex_id'], status['plex_type'])
     if not db_item:
         # Item not (yet) in Kodi library
@@ -466,7 +466,7 @@ def _playback_progress(status, ended, db_item):
     playcount = status['playcount']
     if playcount is None:
         LOG.debug('playcount not found, looking it up in the Kodi DB')
-        with kodi_db.KodiVideoDB() as kodidb:
+        with kodi_db.KodiVideoDB(lock=False) as kodidb:
             playcount = kodidb.get_playcount(db_item['kodi_fileid']) or 0
     if status['external_player']:
         # video has either been entirely watched - or not.
@@ -535,7 +535,7 @@ def _external_player_correct_plex_watch_count(db_item):
     playcountminimumtime set in playercorefactory.xml)
     See https://kodi.wiki/view/External_players
     """
-    with kodi_db.KodiVideoDB() as kodidb:
+    with kodi_db.KodiVideoDB(lock=False) as kodidb:
         playcount = kodidb.get_playcount(db_item['kodi_fileid'])
     LOG.debug('External player detected. Playcount: %s', playcount)
     PF.scrobble(db_item['plex_id'], 'watched' if playcount else 'unwatched')

--- a/resources/lib/library_sync/additional_metadata.py
+++ b/resources/lib/library_sync/additional_metadata.py
@@ -43,7 +43,7 @@ class MetadataThread(backgroundthread.KillableThread):
     def _process_in_batches(self, item_getter, processor, plex_type):
         offset = 0
         while True:
-            with PlexDB() as plexdb:
+            with PlexDB(lock=False) as plexdb:
                 # Keep DB connection open only for a short period of time!
                 if self.refresh:
                     # Simply grab every single item if we want to refresh

--- a/resources/lib/library_sync/additional_metadata_tmdb.py
+++ b/resources/lib/library_sync/additional_metadata_tmdb.py
@@ -48,13 +48,13 @@ def get_tmdb_details(unique_ids):
 def process_trailers(plex_id, plex_type, refresh=False):
     done = True
     try:
-        with PlexDB() as plexdb:
+        with PlexDB(lock=False) as plexdb:
             db_item = plexdb.item_by_id(plex_id, plex_type)
         if not db_item:
             logger.error('Could not get Kodi id for %s %s', plex_type, plex_id)
             done = False
             return
-        with KodiVideoDB() as kodidb:
+        with KodiVideoDB(lock=False) as kodidb:
             trailer = kodidb.get_trailer(db_item['kodi_id'],
                                          db_item['kodi_type'])
         if trailer and (trailer.startswith(f'plugin://{v.ADDON_ID}') or
@@ -103,14 +103,14 @@ def process_fanart(plex_id, plex_type, refresh=False):
     done = True
     try:
         artworks = None
-        with PlexDB() as plexdb:
+        with PlexDB(lock=False) as plexdb:
             db_item = plexdb.item_by_id(plex_id, plex_type)
         if not db_item:
             logger.error('Could not get Kodi id for %s %s', plex_type, plex_id)
             done = False
             return
         if not refresh:
-            with KodiVideoDB() as kodidb:
+            with KodiVideoDB(lock=False) as kodidb:
                 artworks = kodidb.get_art(db_item['kodi_id'],
                                           db_item['kodi_type'])
             # Check if we even need to get additional art

--- a/resources/lib/library_sync/sections.py
+++ b/resources/lib/library_sync/sections.py
@@ -649,7 +649,7 @@ def _sync_from_pms(pick_libraries):
         if api.plex_type in v.UNSUPPORTED_PLEX_TYPES:
             continue
         sections.append(Section(index=i, xml_element=xml_element))
-    with PlexDB() as plexdb:
+    with PlexDB(lock=False) as plexdb:
         for section_db in plexdb.all_sections():
             old_sections.append(Section(section_db_element=section_db))
     # Update our latest PMS sections with info saved in the PMS DB

--- a/resources/lib/library_sync/websocket.py
+++ b/resources/lib/library_sync/websocket.py
@@ -369,6 +369,6 @@ def cache_artwork(plex_id, plex_type, kodi_id=None, kodi_type=None):
             LOG.error('Could not retrieve Plex db info for %s', plex_id)
             return
         kodi_id, kodi_type = item['kodi_id'], item['kodi_type']
-    with kodi_db.KODIDB_FROM_PLEXTYPE[plex_type]() as kodidb:
+    with kodi_db.KODIDB_FROM_PLEXTYPE[plex_type](lock=False) as kodidb:
         for url in kodidb.art_urls(kodi_id, kodi_type):
             artwork.cache_url(url)

--- a/resources/lib/playlists/db.py
+++ b/resources/lib/playlists/db.py
@@ -22,7 +22,7 @@ def plex_playlist_ids():
     """
     Returns a list of all Plex ids of the playlists already in our DB
     """
-    with PlexDB() as plexdb:
+    with PlexDB(lock=False) as plexdb:
         return list(plexdb.playlist_ids())
 
 
@@ -30,7 +30,7 @@ def kodi_playlist_paths():
     """
     Returns a list of all Kodi playlist paths of the playlists already synced
     """
-    with PlexDB() as plexdb:
+    with PlexDB(lock=False) as plexdb:
         return list(plexdb.kodi_playlist_paths())
 
 
@@ -53,7 +53,7 @@ def get_playlist(path=None, plex_id=None):
     Returns the playlist as a Playlist for either the plex_id or path
     """
     playlist = Playlist()
-    with PlexDB() as plexdb:
+    with PlexDB(lock=False) as plexdb:
         playlist = plexdb.playlist(playlist, plex_id, path)
     return playlist
 
@@ -62,7 +62,7 @@ def get_all_kodi_playlist_paths():
     """
     Returns a list with all paths for the playlists on the Kodi side
     """
-    with PlexDB() as plexdb:
+    with PlexDB(lock=False) as plexdb:
         paths = list(plexdb.all_kodi_paths())
     return paths
 
@@ -112,7 +112,7 @@ def m3u_to_plex_ids(playlist):
                                                       db_type=playlist.kodi_type)
             if not kodi_id:
                 continue
-            with PlexDB() as plexdb:
+            with PlexDB(lock=False) as plexdb:
                 item = plexdb.item_by_kodi_id(kodi_id, kodi_type)
             if item:
                 plex_ids.append(item['plex_id'])

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -475,7 +475,7 @@ def wipe_database(reboot=True):
         from .playlists import remove_synced_playlists
         remove_synced_playlists()
     try:
-        with plex_db.PlexDB() as plexdb:
+        with plex_db.PlexDB(lock=False) as plexdb:
             if plexdb.songs_have_been_synced():
                 LOG.info('Detected that music has also been synced - wiping music')
                 music = True


### PR DESCRIPTION
Add `lock=False` to Plex/Kodi DB calls around the codebase to spots where it's only reading data from the database.