### PR TITLE
Fix nested folder navigation

### DIFF
--- a/resources/lib/plex_api/file.py
+++ b/resources/lib/plex_api/file.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from logging import getLogger
 from .. import utils, variables as v, app
 
+
+LOG = getLogger('PLEX.api.file')
 
 def _transcode_image_path(key, AuthToken, path, width, height):
     """
@@ -121,10 +124,15 @@ class File(object):
         key = self.xml.get('fastKey')
         if not key:
             key = self.xml.get('key')
-            if old_key:
-                key = '%s/%s' % (old_key, key)
-            elif not key.startswith('/'):
-                key = '/library/sections/%s/%s' % (section_id, key)
+            LOG.debug('directory_path. section_id: %s, key: %s, old_key: %s', section_id, key, old_key)
+            # the key returned by plex might be an absolute path, ex: "/library/sections/1/folder?parent=3030"
+            # we should directly use the key if it starts with a slash
+            if not key.startswith('/'):
+                if old_key:
+                    key = '%s/%s' % (old_key, key)
+                else:
+                    key = '/library/sections/%s/%s' % (section_id, key)
+                LOG.debug('directory_path. browseplex key will be "%s"', key)
         params = {
             'mode': 'browseplex',
             'key': key


### PR DESCRIPTION
Fixes #2056

Browsing a library fetches plex xml from `https://plexurl:32400/library/sections/1/folder`. The XML response will look like:
```xml
<MediaContainer size="5099" allowSync="1" art="/:/resources/movie-fanart.jpg" content="secondary" identifier="com.plexapp.plugins.library" librarySectionID="1" librarySectionTitle="Movies" librarySectionUUID="052eff28-a524-469b-8243-cbcf295acf7f" mediaTagPrefix="/system/bundle/media/flags/" mediaTagVersion="1710421609" thumb="/:/resources/movie.png" title1="Movies" title2="By Folder" viewGroup="secondary" viewMode="65592">
<Directory key="/library/sections/1/folder?parent=4989" title="abc" />
...
```

The nested directory key for that item was being set to `/library/sections/1/folder//library/sections/1/folder?parent=4989`. It should have been `/library/sections/1/folder?parent=4989`.
Checking for that first `/` before concatenating keys fixed this. I'm not sure if this is the correct fix, but it resolves the issue for me.