### PR TITLE
Add X-Plex-Container-Size to watchlist call and set to maximum

### DIFF
--- a/resources/lib/entrypoint.py
+++ b/resources/lib/entrypoint.py
@@ -494,7 +494,10 @@ def watchlist(section_id=None):
     app.init(entrypoint=True)
     xml = DU().downloadUrl('https://metadata.provider.plex.tv/library/sections/watchlist/all',
                            authenticate=False,
-                           headerOptions={'X-Plex-Token': utils.window('plex_token')})
+                           headerOptions={
+                               'X-Plex-Token': utils.window('plex_token'),
+                               'X-Plex-Container-Size': '300'
+                           })
     try:
         xml[0].attrib
     except (TypeError, IndexError, AttributeError):


### PR DESCRIPTION
Current watchlist api call is limited to 20 items by default, adding X-Plex-Container-Size header allows a larger number to be provided. I have set it to 300 as that is the maximum plex will accept