### PR TITLE
Add support for transcoding into hevc

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1560,3 +1560,8 @@ msgstr ""
 msgctxt "#39725"
 msgid "Force transcode AV1"
 msgstr ""
+
+# PKC Settings - Playback
+msgctxt "#39726"
+msgid "Enable transcoding using h265/HEVC codec (restart Kodi!)"
+msgstr ""

--- a/resources/lib/variables.py
+++ b/resources/lib/variables.py
@@ -468,7 +468,9 @@ STREAMING_HEADERS = {
          'context=streaming&'
          'protocol=hls&'
          'container=mpegts&'
-         'videoCodec=h264&'
+         'videoCodec=h264'
+         + (',hevc' if _ADDON.getSetting('transcodeIntoH265Profile') == 'true' else '') +
+         '&'
          'audioCodec=aac,flac,vorbis,opus,ac3,eac3,mp3,mp2,pcm&'
          'replace=true)'
          # '+add-transcode-target('

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -135,6 +135,7 @@
         <setting id="transcodeH265" type="enum" label="30522" default="0" values="Disabled (default)|480p (and higher)|720p (and higher)|1080p (and higher)|4K" /><!-- Force transcode h265/HEVC -->
         <setting id="transcodeAV1" type="enum" label="39725" default="0" values="Disabled (default)|480p (and higher)|720p (and higher)|1080p (and higher)|4K" /><!-- Force transcode AV1 -->
         <setting id="transcodeHi10P" type="bool" label="39063" default="false"/>
+        <setting id="transcodeIntoH265Profile" type="bool" label="39726" default="false"/>
         <setting id="audioBoost" type="slider" label="39001" default="0" range="0,10,100" option="int"/>
         <setting id="subtitleSize" label="39002" type="slider" option="int" range="0,30,300" default="100" />
         <setting id="force_transcode_pix" type="bool" label="30545" default="false" />


### PR DESCRIPTION
Also requires enabling the HEVC transcode setting in the plex server.  

TODO:
- translations for setting string
- possibly avoid requiring a restart, move the profile extras out of variables.py