### PR TITLE
Fix plex multi disc album numbering

### DIFF
--- a/resources/lib/itemtypes/music.py
+++ b/resources/lib/itemtypes/music.py
@@ -441,11 +441,14 @@ class Song(MusicMixin, ItemBase):
             # compilation not set
             artists = xml.get('originalTitle', api.grandparent_title())
         tracknumber = api.index() or 0
-        disc = api.disc_number() or 0
-        if disc == 0:
+        plex_disc_val = api.disc_number()  # Get the raw disc number from Plex (can be None)
+
+        if plex_disc_val is None:
+            # Single-disc album or disc number not specified by Plex
             track = tracknumber
         else:
-            track = disc * 2 ** 16 + tracknumber
+            # Multi-disc album, plex_disc_val is likely 1, 2, 3,...
+            track = (plex_disc_val * (2**16)) + tracknumber
         year = api.year()
         if not year and album_xml is not None:
             # Plex did not pass year info - get it from the parent album

--- a/resources/lib/itemtypes/music.py
+++ b/resources/lib/itemtypes/music.py
@@ -441,8 +441,8 @@ class Song(MusicMixin, ItemBase):
             # compilation not set
             artists = xml.get('originalTitle', api.grandparent_title())
         tracknumber = api.index() or 0
-        disc = api.disc_number() or 1
-        if disc == 1:
+        disc = api.disc_number() or 0
+        if disc == 0:
             track = tracknumber
         else:
             track = disc * 2 ** 16 + tracknumber


### PR DESCRIPTION
This pull request is related to [https://github.com/croneter/PlexKodiConnect/discussions/1934](https://github.com/croneter/PlexKodiConnect/discussions/1934).  I've spent a few days with these changes now and experienced zero issues.  

This change does require resetting your database.

Refine: Improve disc/track numbering for single and multi-disc albums.  This commit refines the handling of disc and track numbers when syncing music from Plex to Kodi.

Previous behavior:
- Original issue: The first disc of multi-disc albums was often mislabeled as 'Disc 0' and contained all tracks, with subsequent discs also potentially mislabeled.
  Custom skins might not separate discs.
- Interim fix: Multi-disc display was corrected but this introduced an issue where single-disc albums were shown as 'Disc 1' in the library.

This refined change addresses both issues:
- In `resources/lib/itemtypes/music.py` (`Song.add_update`):
    - If Plex provides a disc number (`api.disc_number()` is not None), this value (typically 1-based) is used to encode the disc information into
      Kodi's track number field (`track = (plex_disc_val * (2**16)) + tracknumber`). This ensures correct separation and numbering for multi-disc albums (e.g., Disc 1, Disc 2).
    - If Plex does not provide a disc number (`api.disc_number()` is None), the track number stored in Kodi is the plain track number without disc encoding (`track = tracknumber`). This restores the behavior where single-disc albums do not show "Disc 1" in the library view.

I confirmed:
- Single-disc albums display correctly in the library without disc numbers.
- Multi-disc albums display correctly in the library with disc numbers (Disc 1, Disc 2, etc.).