### PR TITLE
Fix Up Next: Show PKC credits for last episode

### DIFF
--- a/resources/lib/app/playstate.py
+++ b/resources/lib/app/playstate.py
@@ -37,7 +37,8 @@ class PlayState(object):
         'markers': [],
         'markers_hidden': {},
         'first_credits_marker': None,
-        'final_credits_marker': None
+        'final_credits_marker': None,
+        'upnext_signal_sent': False  # Track if Up Next has a next episode
     }
 
     def __init__(self):

--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -719,7 +719,14 @@ class SendUpNextSignal(backgroundthread.Task):
         try:
             # Get notification time from Plex credits markers if available
             notification_time = upnext.get_notification_time_from_markers(self.status)
-            upnext.send_upnext_signal(self.item.api, notification_time)
+            signal_sent = upnext.send_upnext_signal(self.item.api, notification_time)
+            # Store whether Up Next found a next episode
+            # If False, PKC skip credits popup will still show for last episodes
+            with app.APP.lock_playqueues:
+                playerid = self.item.playerid
+                app.PLAYSTATE.player_states[playerid]['upnext_signal_sent'] = signal_sent
+            if not signal_sent:
+                LOG.debug('Up Next: No next episode - PKC skip credits will handle last episode')
         except Exception as err:
             LOG.error('Exception encountered while sending Up Next signal:')
             LOG.error(err)

--- a/resources/lib/skip_plex_markers.py
+++ b/resources/lib/skip_plex_markers.py
@@ -18,9 +18,19 @@ MARKERS = {
 def _should_skip_credits_popup():
     """
     Returns True if we should suppress the PKC credits popup.
-    This happens when Up Next is enabled, as Up Next will handle the credits notification.
+    This happens when Up Next is enabled AND found a next episode.
+    If there's no next episode (last episode), we still show PKC credits popup.
     """
-    return xbmc.getCondVisibility('System.AddonIsEnabled(service.upnext)')
+    if not xbmc.getCondVisibility('System.AddonIsEnabled(service.upnext)'):
+        return False
+
+    # Check if Up Next actually sent a signal (found next episode)
+    with app.APP.lock_playqueues:
+        if len(app.PLAYSTATE.active_players) != 1:
+            return False
+        playerid = list(app.PLAYSTATE.active_players)[0]
+        player_state = app.PLAYSTATE.player_states.get(playerid, {})
+        return player_state.get('upnext_signal_sent', False)
 
 def skip_markers(markers, markers_hidden):
     try:


### PR DESCRIPTION
When Up Next is enabled but no next episode is available (last episode in season/series), PKC's skip credits popup was being suppressed. This fix checks the return value of send_upnext_signal() and only suppresses PKC credits when Up Next actually found a next episode.

For the last episode case:
- Up Next returns False (no next episode found)
- PKC's skip credits popup will now show properly
- Users can still skip end credits for last episodes

Changes:
- Add upnext_signal_sent flag to player state to track Up Next result
- Store send_upnext_signal() return value in SendUpNextSignal task
- Only suppress PKC credits popup when Up Next found next episode
- Keep existing Up Next integration unchanged