### PR TITLE
Fix PMS stop registering playback state after 6-10 music tracks

### DIFF
--- a/resources/lib/plex_companion/playqueue.py
+++ b/resources/lib/plex_companion/playqueue.py
@@ -95,7 +95,7 @@ def compare_playqueues(playqueue, new_kodi_playqueue):
                     log.error('Could not modify playqueue positions')
                     log.error('This is likely caused by mixing audio and '
                               'video tracks in the Kodi playqueue')
-                del old[j], index[i]
+                del old[j], index[j]
                 break
         else:
             log.debug('Detected new Kodi element at position %s: %s ',


### PR DESCRIPTION
After 6-10 music tracks, PMS stops registering playback state. Music continues playing fine, but nothing reflects as playing on PMS until Kodi is restarted. This breaks webhooks that rely on client playback states.

Fix IndexError when playlist items are moved in Kodi. The deletion statement `del old[j], index[i]` used incorrect loop variable - should delete `index[j]` to match the found position, not `index[i]` which may exceed list bounds after prior deletions.