### PR TITLE
Revert "Fix PMS stop registering playback state after 6-10 music tracks"

### DIFF
--- a/resources/lib/plex_companion/playqueue.py
+++ b/resources/lib/plex_companion/playqueue.py
@@ -95,7 +95,7 @@ def compare_playqueues(playqueue, new_kodi_playqueue):
                     log.error('Could not modify playqueue positions')
                     log.error('This is likely caused by mixing audio and '
                               'video tracks in the Kodi playqueue')
-                del old[j], index[j]
+                del old[j], index[i]
                 break
         else:
             log.debug('Detected new Kodi element at position %s: %s ',


### PR DESCRIPTION
Reverts croneter/PlexKodiConnect#2224

This logic is incorrect, leading to the observed behavior plex believing the previous episode is still playing when advancing to the next via Up Next. See https://github.com/croneter/PlexKodiConnect/pull/2224#issuecomment-4274862780

There may be additional edge cases, but the prior logic was more correct. It certainly doesn't make sense to expect the same index to have comparable meaning over two different mutable lists.