### PR TITLE
Fix wrong item being deleted from the Plex playqueue

### DIFF
--- a/resources/lib/plex_companion/playqueue.py
+++ b/resources/lib/plex_companion/playqueue.py
@@ -87,14 +87,18 @@ def compare_playqueues(playqueue, new_kodi_playqueue):
                 del old[0], index[0]
                 break
             elif identical:
-                log.debug('Playqueue item %s moved to position %s',
-                          index[j], i)
+                src = index[j]
+                log.debug('Playqueue item %s moved to position %s', src, i)
                 try:
-                    PL.move_playlist_item(playqueue, index[j], i)
+                    PL.move_playlist_item(playqueue, src, i)
                 except exceptions.PlaylistError:
                     log.error('Could not modify playqueue positions')
                     log.error('This is likely caused by mixing audio and '
                               'video tracks in the Kodi playqueue')
+                    return
+                for k, pos in enumerate(index):
+                    if i <= pos < src:
+                        index[k] = pos + 1
                 del old[j], index[j]
                 break
         else:
@@ -126,8 +130,9 @@ def compare_playqueues(playqueue, new_kodi_playqueue):
                 # Also see kodimonitor.py - _playlist_onadd()
                 pass
             else:
-                for j in range(i, len(index)):
-                    index[j] += 1
+                for k, pos in enumerate(index):
+                    if pos >= i:
+                        index[k] = pos + 1
     for i in reversed(index):
         if app.APP.stop_pkc:
             # Chances are that we got an empty Kodi playlist due to


### PR DESCRIPTION
@camhorn spotted this on #2224. You were right, thanks for the catch.

`compare_playqueues()` records each remaining item's position in the Plex playqueue in `index`, but never updates it after a move or an insertion, so the deletion loop at the end works from stale positions.

Reproduced on Kodi/Windows against a live PMS: queue three tracks, skip to the last, remove the first, and the *second* track disappears from the Plex queue instead. With this patch the correct one goes. Reordering and adding tracks still behave.

Also returns rather than carrying on when `move_playlist_item()` fails, since the shift assumes the move happened.
